### PR TITLE
add:新規投稿機能とバリデーションの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,0 +1,71 @@
+class SpotsController < ApplicationController
+  before_action :set_spot, only: %i[ show edit update destroy ]
+  skip_before_action :authenticate_user!, only: %i[ index show ]
+
+  # GET /spots or /spots.json
+  def index
+    @spots = Spot.all
+  end
+
+  # GET /spots/1 or /spots/1.json
+  def show
+  end
+
+  # GET /spots/new
+  def new
+    @spot = current_user.spots.build
+  end
+
+  # GET /spots/1/edit
+  def edit
+  end
+
+  # POST /spots or /spots.json
+  def create
+    @spot = current_user.spots.build(spot_params)
+
+    respond_to do |format|
+      if @spot.save
+        format.html { redirect_to @spot, notice: "Spot was successfully created." }
+        format.json { render :show, status: :created, location: @spot }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @spot.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /spots/1 or /spots/1.json
+  def update
+    respond_to do |format|
+      if @spot.update(spot_params)
+        format.html { redirect_to @spot, notice: "Spot was successfully updated." }
+        format.json { render :show, status: :ok, location: @spot }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @spot.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /spots/1 or /spots/1.json
+  def destroy
+    @spot.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to spots_path, status: :see_other, notice: "Spot was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_spot
+      @spot = Spot.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def spot_params
+      params.require(:spot).permit(:name, :prefecture_id, :address, :url, :body)
+    end
+end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,5 @@
 class TopController < ApplicationController
-  def home
-  end
+  skip_before_action :authenticate_user!
+
+  def home; end
 end

--- a/app/helpers/spots_helper.rb
+++ b/app/helpers/spots_helper.rb
@@ -1,0 +1,2 @@
+module SpotsHelper
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,3 @@
+class Prefecture < ApplicationRecord
+  has_many :spots
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,0 +1,8 @@
+class Spot < ApplicationRecord
+  belongs_to :user
+  belongs_to :prefecture
+
+  validates :name, presence: true
+  validates :address, presence: true
+  validates :url, format: { with: URI.regexp(%w[http https]), message: "は有効なURL形式でなければなりません" }, allow_blank: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 100 }
+  has_many :spots
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer-center bg-base-200 text-base-content rounded p-10">
+<footer class="footer footer-center bg-base-200 text-base-content rounded p-10 mt-5">
   <nav class="grid grid-flow-col gap-4">
     <a class="link link-hover">お問い合わせ</a>
     <a class="link link-hover">利用規約</a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100">
+<div class="navbar bg-base-100 mb-5">
   <div class="flex-1">
     <%= link_to 'NighTrip', root_path, class: 'btn btn-ghost text-xl' %>
   </div>
@@ -17,10 +17,10 @@
         </li>
       <% end %>
       <li>
-        <%= link_to "新規投稿", "#" %>
+        <%= link_to "新規投稿", new_spot_path %>
       </li>
       <li>
-        <%= link_to "検索する", "#" %>
+        <%= link_to "検索する", spots_path %>
       </li>
     </ul>
   </div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_with(model: spot, class: "contents") do |form| %>
+  <% if spot.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-md mt-3">
+      <h2><%= pluralize(spot.errors.count, "error") %> prohibited this spot from being saved:</h2>
+
+      <ul class="list-disc ml-6">
+        <% spot.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :name %>
+    <%= form.text_field :name, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": spot.errors[:name].none?, "border-red-400 focus:outline-red-600": spot.errors[:name].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :prefecture_id %>
+    <%= form.select :prefecture_id, Prefecture.all.collect { |p| [p.name, p.id] }, { include_blank: "選択してください" }, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": spot.errors[:prefecture_id].none?, "border-red-400 focus:outline-red-600": spot.errors[:prefecture_id].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :address %>
+    <%= form.text_field :address, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": spot.errors[:address].none?, "border-red-400 focus:outline-red-600": spot.errors[:address].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :url %>
+    <%= form.text_field :url, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": spot.errors[:url].none?, "border-red-400 focus:outline-red-600": spot.errors[:url].any?}] %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :body %>
+    <%= form.text_area :body, rows: 4, class: ["block shadow rounded-md border outline-none px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": spot.errors[:body].none?, "border-red-400 focus:outline-red-600": spot.errors[:body].any?}] %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,0 +1,26 @@
+<div id="<%= dom_id spot %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Name:</strong>
+    <%= spot.name %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Prefecture:</strong>
+    <%= spot.prefecture_id %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Address:</strong>
+    <%= spot.address %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Url:</strong>
+    <%= spot.url %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Body:</strong>
+    <%= spot.body %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">User:</strong>
+    <%= spot.user_id %>
+  </p>
+</div>

--- a/app/views/spots/_spot.json.jbuilder
+++ b/app/views/spots/_spot.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! spot, :id, :name, :prefecture_id, :address, :url, :body, :user_id, :created_at, :updated_at
+json.url spot_url(spot, format: :json)

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "Editing spot" %>
+
+<div class="md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing spot</h1>
+
+  <%= render "form", spot: @spot %>
+
+  <%= link_to "Show this spot", @spot, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <%= link_to "Back to spots", spots_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+</div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Spots" %>
+
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Spots</h1>
+  </div>
+
+  <div id="spots" class="min-w-full">
+    <% if @spots.any? %>
+      <% @spots.each do |spot| %>
+        <%= render spot %>
+        <p>
+          <%= link_to "Show this spot", spot, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+        </p>
+      <% end %>
+    <% else %>
+      <p class="text-center my-10">No spots found.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/spots/index.json.jbuilder
+++ b/app/views/spots/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @spots, partial: "spots/spot", as: :spot

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "New spot" %>
+
+<div class="md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New spot</h1>
+
+  <%= render "form", spot: @spot %>
+
+  <%= link_to "Back to spots", spots_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+</div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Showing spot" %>
+
+<div class="md:w-2/3 w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Showing spot</h1>
+
+  <%= render @spot %>
+
+  <%= link_to "Edit this spot", edit_spot_path(@spot), class: "mt-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <%= link_to "Back to spots", spots_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <div class="inline-block ml-2">
+    <%= button_to "Destroy this spot", @spot, method: :delete, class: "mt-2 rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium" %>
+  </div>
+</div>

--- a/app/views/spots/show.json.jbuilder
+++ b/app/views/spots/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "spots/spot", spot: @spot

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :spots
   devise_for :users
   root to: "top#home"
 end

--- a/db/migrate/20250201110350_create_spots.rb
+++ b/db/migrate/20250201110350_create_spots.rb
@@ -1,0 +1,14 @@
+class CreateSpots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spots do |t|
+      t.string :name
+      t.integer :prefecture_id
+      t.string :address
+      t.string :url
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250201110600_create_prefectures.rb
+++ b/db/migrate/20250201110600_create_prefectures.rb
@@ -1,0 +1,10 @@
+class CreatePrefectures < ActiveRecord::Migration[7.2]
+  def change
+    create_table :prefectures do |t|
+      t.string :name
+      t.integer :region
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250201112513_add_foreign_key_to_spots.rb
+++ b/db/migrate/20250201112513_add_foreign_key_to_spots.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToSpots < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :spots, :prefectures
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_30_190026) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_01_112513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "prefectures", force: :cascade do |t|
+    t.string "name"
+    t.integer "region"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "spots", force: :cascade do |t|
+    t.string "name"
+    t.integer "prefecture_id"
+    t.string "address"
+    t.string "url"
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_spots_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +45,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_190026) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "spots", "prefectures"
+  add_foreign_key "spots", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,55 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# マスターテーブル設定
+## prefecturesテーブル
+prefectures = [
+  { name: "北海道", region: 0 },  # 北海道地方
+  { name: "青森県", region: 1 },  # 東北地方
+  { name: "岩手県", region: 1 },
+  { name: "宮城県", region: 1 },
+  { name: "秋田県", region: 1 },
+  { name: "山形県", region: 1 },
+  { name: "福島県", region: 1 },
+  { name: "茨城県", region: 2 },  # 関東地方
+  { name: "栃木県", region: 2 },
+  { name: "群馬県", region: 2 },
+  { name: "埼玉県", region: 2 },
+  { name: "千葉県", region: 2 },
+  { name: "東京都", region: 2 },
+  { name: "神奈川県", region: 2 },
+  { name: "新潟県", region: 3 },  # 中部地方
+  { name: "富山県", region: 3 },
+  { name: "石川県", region: 3 },
+  { name: "福井県", region: 3 },
+  { name: "山梨県", region: 4 },  # 甲信越地方
+  { name: "長野県", region: 4 },
+  { name: "岐阜県", region: 5 },  # 東海地方
+  { name: "静岡県", region: 5 },
+  { name: "愛知県", region: 5 },
+  { name: "三重県", region: 5 },
+  { name: "滋賀県", region: 6 },  # 近畿地方
+  { name: "京都府", region: 6 },
+  { name: "大阪府", region: 6 },
+  { name: "兵庫県", region: 6 },
+  { name: "奈良県", region: 6 },
+  { name: "和歌山県", region: 6 },
+  { name: "鳥取県", region: 7 },  # 中国地方
+  { name: "島根県", region: 7 },
+  { name: "岡山県", region: 7 },
+  { name: "広島県", region: 7 },
+  { name: "山口県", region: 7 },
+  { name: "徳島県", region: 8 },  # 四国地方
+  { name: "香川県", region: 8 },
+  { name: "愛媛県", region: 8 },
+  { name: "高知県", region: 8 },
+  { name: "福岡県", region: 9 },  # 九州地方
+  { name: "佐賀県", region: 9 },
+  { name: "長崎県", region: 9 },
+  { name: "熊本県", region: 9 },
+  { name: "大分県", region: 9 },
+  { name: "宮崎県", region: 9 },
+  { name: "鹿児島県", region: 9 },
+  { name: "沖縄県", region: 9 }
+]
+
+prefectures.each do |prefecture|
+  Prefecture.create(name: prefecture[:name], region: prefecture[:region])
+end

--- a/test/controllers/spots_controller_test.rb
+++ b/test/controllers/spots_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class SpotsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    # 動的にユーザーを作成（ユーザーのインデックスは `n` に基づく）
+    @user = User.create!(
+      email: "user#{Time.now.to_i}0@example.com",  # この部分は動的に変更
+      password: "password",
+      name: "user0"
+    )
+
+    sign_in @user  # ログイン処理
+    @spot = Spot.create(name: "Test Spot", address: "Test Address", body: "Test Body", prefecture_id: 1, url: "http://example.com", user_id: @user.id)
+  end
+
+  test "should get index" do
+    get spots_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_spot_url
+    assert_response :success
+  end
+
+  test "should create spot" do
+    assert_difference("Spot.count") do
+      post spots_url, params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url, user_id: @user.id } }
+    end
+
+    assert_redirected_to spot_url(Spot.last)
+  end
+
+  test "should show spot" do
+    get spot_url(@spot)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_spot_url(@spot)
+    assert_response :success
+  end
+
+  test "should update spot" do
+    patch spot_url(@spot), params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url } }
+    assert_redirected_to spot_url(@spot)
+  end
+
+  test "should destroy spot" do
+    assert_difference("Spot.count", -1) do
+      delete spot_url(@spot)
+    end
+
+    assert_redirected_to spots_url
+  end
+end

--- a/test/fixtures/prefectures.yml
+++ b/test/fixtures/prefectures.yml
@@ -1,0 +1,234 @@
+hokkaido:
+  id: 1
+  name: "北海道"
+  region: 0
+
+aomori:
+  id: 2
+  name: "青森県"
+  region: 1
+
+iwate:
+  id: 3
+  name: "岩手県"
+  region: 1
+
+miyagi:
+  id: 4
+  name: "宮城県"
+  region: 1
+
+akita:
+  id: 5
+  name: "秋田県"
+  region: 1
+
+yamagata:
+  id: 6
+  name: "山形県"
+  region: 1
+
+fukushima:
+  id: 7
+  name: "福島県"
+  region: 1
+
+ibaraki:
+  id: 8
+  name: "茨城県"
+  region: 2
+
+tochigi:
+  id: 9
+  name: "栃木県"
+  region: 2
+
+gunma:
+  id: 10
+  name: "群馬県"
+  region: 2
+
+saitama:
+  id: 11
+  name: "埼玉県"
+  region: 2
+
+chiba:
+  id: 12
+  name: "千葉県"
+  region: 2
+
+tokyo:
+  id: 13
+  name: "東京都"
+  region: 2
+
+kanagawa:
+  id: 14
+  name: "神奈川県"
+  region: 2
+
+niigata:
+  id: 15
+  name: "新潟県"
+  region: 3
+
+toyama:
+  id: 16
+  name: "富山県"
+  region: 3
+
+ishikawa:
+  id: 17
+  name: "石川県"
+  region: 3
+
+fukui:
+  id: 18
+  name: "福井県"
+  region: 3
+
+yamanashi:
+  id: 19
+  name: "山梨県"
+  region: 4
+
+nagano:
+  id: 20
+  name: "長野県"
+  region: 4
+
+gifu:
+  id: 21
+  name: "岐阜県"
+  region: 5
+
+shizuoka:
+  id: 22
+  name: "静岡県"
+  region: 5
+
+aichi:
+  id: 23
+  name: "愛知県"
+  region: 5
+
+mie:
+  id: 24
+  name: "三重県"
+  region: 5
+
+shiga:
+  id: 25
+  name: "滋賀県"
+  region: 6
+
+kyoto:
+  id: 26
+  name: "京都府"
+  region: 6
+
+osaka:
+  id: 27
+  name: "大阪府"
+  region: 6
+
+hyogo:
+  id: 28
+  name: "兵庫県"
+  region: 6
+
+nara:
+  id: 29
+  name: "奈良県"
+  region: 6
+
+wakayama:
+  id: 30
+  name: "和歌山県"
+  region: 6
+
+tottori:
+  id: 31
+  name: "鳥取県"
+  region: 7
+
+shimane:
+  id: 32
+  name: "島根県"
+  region: 7
+
+okayama:
+  id: 33
+  name: "岡山県"
+  region: 7
+
+hiroshima:
+  id: 34
+  name: "広島県"
+  region: 7
+
+yamaguchi:
+  id: 35
+  name: "山口県"
+  region: 7
+
+tokushima:
+  id: 36
+  name: "徳島県"
+  region: 8
+
+kagawa:
+  id: 37
+  name: "香川県"
+  region: 8
+
+ehime:
+  id: 38
+  name: "愛媛県"
+  region: 8
+
+kochi:
+  id: 39
+  name: "高知県"
+  region: 8
+
+fukuoka:
+  id: 40
+  name: "福岡県"
+  region: 9
+
+saga:
+  id: 41
+  name: "佐賀県"
+  region: 9
+
+nagasaki:
+  id: 42
+  name: "長崎県"
+  region: 9
+
+kumamoto:
+  id: 43
+  name: "熊本県"
+  region: 9
+
+oita:
+  id: 44
+  name: "大分県"
+  region: 9
+
+miyazaki:
+  id: 45
+  name: "宮崎県"
+  region: 9
+
+kagoshima:
+  id: 46
+  name: "鹿児島県"
+  region: 9
+
+okinawa:
+  id: 47
+  name: "沖縄県"
+  region: 9

--- a/test/fixtures/spots.yml
+++ b/test/fixtures/spots.yml
@@ -1,0 +1,7 @@
+one:
+  name: "Test Spot"
+  prefecture_id: 1
+  address: "Test Address"
+  url: "http://example.com"
+  body: "Test Body"
+  user: user_0

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,6 @@
-one:
-  email: "user1@example.com"
-  name: "User One"
-  # 他のカラムも必要に応じて追加
-
-two:
-  email: "user2@example.com"
-  name: "User Two"
-  # 他のカラムも必要に応じて追加
+<% 10.times do |n| %>
+user_<%= n %>:
+  email: <%= "user#{n}@example.com" %>
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  name: <%= "user#{n}" %>
+<% end %>

--- a/test/models/prefecture_test.rb
+++ b/test/models/prefecture_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PrefectureTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/spot_test.rb
+++ b/test/models/spot_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpotTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -1,8 +1,12 @@
 require "application_system_test_case"
 
 class SpotsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
   setup do
-    @spot = spots(:one)
+    @user = User.create!(email: "user@example.com", password: "password", name: "Test User") # @user の作成
+    sign_in @user  # ログイン処理
+    @spot = spots(:one) # 既存のスポットデータを使用
   end
 
   test "visiting the index" do
@@ -14,12 +18,12 @@ class SpotsTest < ApplicationSystemTestCase
     visit spots_url
     click_on "新規投稿"
 
-    fill_in "Address", with: @spot.address
-    fill_in "Body", with: @spot.body
-    fill_in "Name", with: @spot.name
-    fill_in "Prefecture", with: @spot.prefecture_id
-    fill_in "Url", with: @spot.url
-    fill_in "User", with: @spot.user_id
+    fill_in "spot_address", with: @spot.address
+    fill_in "spot_body", with: @spot.body
+    fill_in "spot_name", with: @spot.name
+    select @spot.prefecture.name, from: "spot[prefecture_id]"
+    fill_in "spot_url", with: @spot.url
+    # fill_in "User", with: @spot.user_id
     click_on "Create Spot"
 
     assert_text "Spot was successfully created"
@@ -43,8 +47,6 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should destroy Spot" do
-    sign_in @user
-
     visit spot_url(@spot)
 
     accept_confirm do # 確認ダイアログ（JavaScript の confirm）が表示された際にキャンセルされる可能性があるため必要

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -12,7 +12,7 @@ class SpotsTest < ApplicationSystemTestCase
 
   test "should create spot" do
     visit spots_url
-    click_on "New spot"
+    click_on "新規投稿"
 
     fill_in "Address", with: @spot.address
     fill_in "Body", with: @spot.body
@@ -30,12 +30,12 @@ class SpotsTest < ApplicationSystemTestCase
     visit spot_url(@spot)
     click_on "Edit this spot", match: :first
 
-    fill_in "Address", with: @spot.address
-    fill_in "Body", with: @spot.body
-    fill_in "Name", with: @spot.name
-    fill_in "Prefecture", with: @spot.prefecture_id
-    fill_in "Url", with: @spot.url
-    fill_in "User", with: @spot.user_id
+    fill_in "spot_address", with: @spot.address
+    fill_in "spot_body", with: @spot.body
+    fill_in "spot_name", with: @spot.name
+    select @spot.prefecture.name, from: "spot[prefecture_id]"
+    fill_in "spot_url", with: @spot.url
+    # select @spot.user.name, from: "spot[user_id]"
     click_on "Update Spot"
 
     assert_text "Spot was successfully updated"
@@ -43,8 +43,13 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should destroy Spot" do
+    sign_in @user
+
     visit spot_url(@spot)
-    click_on "Destroy this spot", match: :first
+
+    accept_confirm do # 確認ダイアログ（JavaScript の confirm）が表示された際にキャンセルされる可能性があるため必要
+      click_on "Destroy this spot", match: :first
+    end
 
     assert_text "Spot was successfully destroyed"
   end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -49,9 +49,7 @@ class SpotsTest < ApplicationSystemTestCase
   test "should destroy Spot" do
     visit spot_url(@spot)
 
-    accept_confirm do # 確認ダイアログ（JavaScript の confirm）が表示された際にキャンセルされる可能性があるため必要
-      click_on "Destroy this spot", match: :first
-    end
+    click_on "Destroy this spot", match: :first
 
     assert_text "Spot was successfully destroyed"
   end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -1,0 +1,51 @@
+require "application_system_test_case"
+
+class SpotsTest < ApplicationSystemTestCase
+  setup do
+    @spot = spots(:one)
+  end
+
+  test "visiting the index" do
+    visit spots_url
+    assert_selector "h1", text: "Spots"
+  end
+
+  test "should create spot" do
+    visit spots_url
+    click_on "New spot"
+
+    fill_in "Address", with: @spot.address
+    fill_in "Body", with: @spot.body
+    fill_in "Name", with: @spot.name
+    fill_in "Prefecture", with: @spot.prefecture_id
+    fill_in "Url", with: @spot.url
+    fill_in "User", with: @spot.user_id
+    click_on "Create Spot"
+
+    assert_text "Spot was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Spot" do
+    visit spot_url(@spot)
+    click_on "Edit this spot", match: :first
+
+    fill_in "Address", with: @spot.address
+    fill_in "Body", with: @spot.body
+    fill_in "Name", with: @spot.name
+    fill_in "Prefecture", with: @spot.prefecture_id
+    fill_in "Url", with: @spot.url
+    fill_in "User", with: @spot.user_id
+    click_on "Update Spot"
+
+    assert_text "Spot was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Spot" do
+    visit spot_url(@spot)
+    click_on "Destroy this spot", match: :first
+
+    assert_text "Spot was successfully destroyed"
+  end
+end


### PR DESCRIPTION
# 作業内容
## Spotリソースを作成（モデル・コントローラ・ルーティング）
  - [x] 以下を実行
  ```bash
  rails g scaffold spot name:string prefecture_id:integer address:string url:string body:text user:references
  ```
  - [x] 以下を実行
  ```bash
  rails db:migrate
  ```
## マスターテーブル（都道府県）を作成
  - [x] 以下を実行
  ```bash
  rails g model Prefecture name:string region:integer
  ```
  - [x] 以下を実行
   ```bash
   rails db:migrate
   ```
  - [x] `db/seeds.rb` に都道府県データを追加（マスターテーブルの初期データ投入のため）
  - [x] 以下を実行
  ```bash
  rails db:seed
  ```
  - [x] データ投入確認のため以下を実行
  ```bash
  rails c
  ```
  ```bash
  Prefecture.all
  ```
## 投稿フォームを作成（都道府県選択機能含む）
  - [x] `spots/_form.html.erb`を編集
    - `prefecture_id` を選択式にし、placeholderを追記
    - `user_id`について、項目を削除（自動的に参照される形式にしたいため）
## 投稿処理を実装（バリデーション含む）
### コントローラーを編集
- [x]  基本的にどのアクションでもログインを求める処理を`application_controller.rb`に追記
- [x]  TOPページにログインを求めるのは、skipする処理を追記
- [x] `spots_controller.rb`のストロングパラメーターから`user_id`を削除
- [x] spot作成系アクション（newとcreate）の処理を`.new`から`.build`にすることで、ログイン中のユーザー情報を参照するように変更
- [x] `spots_controller.rb`について、`index`と`show`の際にはログインを不要とするように追記

`top/home.html.erb` に追記 
## 依存関係を明記（関連付け・バリデーション）
  - [x]  `Spot`モデル設定を記述
    - `prefectures` マスターテーブルとの関係
    - `name`カラムと`address`カラムに`presence`制約
    - `url`カラムに正規表現制約
  - [x]  `Spot`テーブルの`prefecture_id`に外部キー制約を付与
  ```bash
  rails g migration AddForeignKeyToSpots
  ```
  - [x] マイグレーションファイルに`spots`テーブルの`prefecture_id` カラムに対して`prefectures`テーブルとの外部キー制約を追加する記述を追記
  ```ruby
  class AddForeignKeyToSpots < ActiveRecord::Migration[7.2]
    def change
      add_foreign_key :spots, :prefectures
    end
  end
  ```
  - [x]  以下を実行
  ```bash
  rails db:migrate
  ```
  ### Prefectureモデルに関連付けを明記
  - [x]  `prefecture.rb` に追記
  ### Userモデルに関連付けを明記
  - [x]  `user.rb` に追記
## 投稿が可能か確認
### 新規投稿のリンクを更新
- [x] `_header.html.erb` を編集
  - [x] 「新規投稿」のリンクを最適化
  - [x] 「検索する」のリンクを最適化
# 備考