### PR TITLE
fix:Dockerfile.prodにビルドスクリプトが走るように追記

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -27,7 +27,9 @@ RUN yarn install --production
 
 COPY . /myapp
 
-RUN bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompiles
+
+RUN bin/render-build.sh
 
 EXPOSE 3000
 

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,7 +1,7 @@
 set -o errexit
 
 bundle install
-bundle exec rake assets:precompile
-bundle exec rake assets:clean
-bundle exec rails db:migrate
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+RAILS_ENV=production bundle exec rails db:migrate
 RAILS_ENV=production bundle exec rails db:seed


### PR DESCRIPTION
# 作業内容
- [x] Dockerfile.prodに以下を追記
```docker
RUN bin/render-build.sh
```
- [x] render-build.shに以下を追記
```sh
RAILS_ENV=production bundle exec rails db:migrate
RAILS_ENV=production bundle exec rails db:seed
```
# 備考