### PR TITLE
add:投稿編集に関連するレイアウトの編集

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,5 +1,5 @@
 class SpotsController < ApplicationController
-  before_action :set_spot, only: %i[ show edit update destroy ]
+  before_action :set_spot, only: %i[ edit update destroy ]
   skip_before_action :authenticate_user!, only: %i[ index show ]
 
   # GET /spots or /spots.json
@@ -9,6 +9,7 @@ class SpotsController < ApplicationController
 
   # GET /spots/1 or /spots/1.json
   def show
+    @spot = Spot.find(params[:id])
   end
 
   # GET /spots/new
@@ -61,7 +62,7 @@ class SpotsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_spot
-      @spot = Spot.find(params[:id])
+      @spot = current_user.spots.find(params[:id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 100 }
   has_many :spots, dependent: :destroy
+
+  def own?(object)
+    id == object&.user.id
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <ul class="menu menu-horizontal px-1">
       <% if user_signed_in? %>
         <li>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete %>
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
         </li>
       <% else %>
         <li>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -39,9 +39,15 @@
   <div class="my-5">
     <%= form.label :image, class: "label" %>
     <%= form.file_field :image, class: ["file-input file-input-bordered file-input-primary w-full mt-2", {"border-gray-400": spot.errors[:image].none?, "border-red-400": spot.errors[:image].any?}] %>
+
+    <% if spot.image.attached? %>
+      <div class="mt-3">
+        <%= image_tag spot.image.variant(resize_to_limit: [300, 300]) %>
+      </div>
+    <% end %>
   </div>
 
-  <div class="inline">
-    <%= form.submit class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+  <div class="flex w-3/5 flex-col border-opacity-50 mx-auto">
+    <%= form.submit class: "btn btn-primary w-full" %>
   </div>
 <% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -5,7 +5,7 @@
   </p>
   <p class="my-5">
     <strong class="block font-medium mb-1">Prefecture:</strong>
-    <%= spot.prefecture_id %>
+    <%= spot.prefecture.name %>
   </p>
   <p class="my-5">
     <strong class="block font-medium mb-1">Address:</strong>
@@ -21,7 +21,7 @@
   </p>
   <p class="my-5">
     <strong class="block font-medium mb-1">User:</strong>
-    <%= spot.user_id %>
+    <%= spot.user.name %>
   </p>
   <p class="my-5">
     <strong class="block font-medium mb-1">Image:</strong>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -5,6 +5,15 @@
 
   <%= render "form", spot: @spot %>
 
-  <%= link_to "Show this spot", @spot, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to spots", spots_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <div class="flex w-3/5 flex-col border-opacity-50 mx-auto">
+    <div class="divider">OR</div>
+    <!-- button to show a spot -->
+    <div class="card bg-base-300 rounded-box grid place-items-center mb-5">
+      <%= link_to "投稿詳細", @spot, class: "btn btn-primary w-full" %>
+    </div>
+    <div class="card bg-base-300 rounded-box grid place-items-center">
+      <%= link_to "投稿一覧に戻る", spots_path, class: "btn btn-primary w-full" %>
+    </div>
+  </div>
+
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -9,9 +9,23 @@
 
   <%= render @spot %>
 
-  <%= link_to "Edit this spot", edit_spot_path(@spot), class: "mt-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to spots", spots_path, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <div class="inline-block ml-2">
-    <%= button_to "Destroy this spot", @spot, method: :delete, class: "mt-2 rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium" %>
+  <div class="flex w-3/5 flex-col border-opacity-50 mx-auto">
+    <% if current_user.own?(@spot) %>
+      <!-- button to edit a spot -->
+      <div class="card bg-base-300 rounded-box grid place-items-center mb-5">
+        <%= link_to "投稿を編集", edit_spot_path(@spot), class: "btn btn-primary w-full" %>
+      </div>
+      <!-- button to delete a spot -->
+      <div class="card bg-base-300 rounded-box grid place-items-center">
+        <%= link_to "投稿を削除", @spot, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error w-full" %>
+      </div>
+      <div class="divider">OR</div>
+    <% end %>
+
+    <div class="card bg-base-300 rounded-box grid place-items-center">
+      <%= link_to "投稿一覧に戻る", spots_path, class: "btn btn-primary w-full" %>
+    </div>
   </div>
+
+
 </div>

--- a/test/fixtures/spots.yml
+++ b/test/fixtures/spots.yml
@@ -6,3 +6,12 @@ one:
   url: "http://example.com"
   user: user_0
   image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>
+
+two:
+  name: "Another Spot"
+  address: "Another Address"
+  body: "Another Body"
+  prefecture_id: 1
+  url: "http://example.com"
+  user: user_1
+  image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -65,7 +65,9 @@ class SpotsTest < ApplicationSystemTestCase
   test "should destroy Spot" do
     visit spot_url(@spot)
 
-    click_on "投稿を削除", match: :first
+    accept_alert do
+      click_on "投稿を削除", match: :first
+    end
 
     assert_text "Spot was successfully destroyed"
   end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -20,6 +20,7 @@ class SpotsTest < ApplicationSystemTestCase
       url: "https://example.com",
       body: "テスト用のスポットです。",
       prefecture_id: prefecture.id,
+      user: @user,
       image: Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test_image.png"), "image/png")
     )
   end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -27,12 +27,12 @@ class SpotsTest < ApplicationSystemTestCase
     click_on "Create Spot"
 
     assert_text "Spot was successfully created"
-    click_on "Back"
+    click_on "投稿一覧に戻る"
   end
 
   test "should update Spot" do
     visit spot_url(@spot)
-    click_on "Edit this spot", match: :first
+    click_on "投稿を編集", match: :first
 
     fill_in "spot_address", with: @spot.address
     fill_in "spot_body", with: @spot.body
@@ -43,13 +43,13 @@ class SpotsTest < ApplicationSystemTestCase
     click_on "Update Spot"
 
     assert_text "Spot was successfully updated"
-    click_on "Back"
+    click_on "投稿一覧に戻る"
   end
 
   test "should destroy Spot" do
     visit spot_url(@spot)
 
-    click_on "Destroy this spot", match: :first
+    click_on "投稿を削除", match: :first
 
     assert_text "Spot was successfully destroyed"
   end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -4,9 +4,24 @@ class SpotsTest < ApplicationSystemTestCase
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @user = User.create!(email: "user@example.com", password: "password", name: "Test User") # @user の作成
+    @user = User.create!(
+      email: "user@example.com",
+      password: "password",
+      name: "Test User"
+    )
+
     sign_in @user  # ログイン処理
-    @spot = spots(:one) # 既存のスポットデータを使用
+
+    prefecture = Prefecture.find_by(name: "東京都") || Prefecture.create!(name: "東京都", region: 2)
+
+    @spot = Spot.create!(
+      name: "テストスポット",
+      address: "東京都新宿区",
+      url: "https://example.com",
+      body: "テスト用のスポットです。",
+      prefecture_id: prefecture.id,
+      image: fixture_file_upload(Rails.root.join("test", "fixtures", "files", "test_image.png"), "image/png")
+    )
   end
 
   test "visiting the index" do

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -20,7 +20,7 @@ class SpotsTest < ApplicationSystemTestCase
       url: "https://example.com",
       body: "テスト用のスポットです。",
       prefecture_id: prefecture.id,
-      image: fixture_file_upload(Rails.root.join("test", "fixtures", "files", "test_image.png"), "image/png")
+      image: Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test_image.png"), "image/png")
     )
   end
 
@@ -30,7 +30,6 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should create spot" do
-    sign_in @user
     visit spots_url
     click_on "新規投稿"
 
@@ -47,7 +46,6 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should update Spot" do
-    sign_in @user
     visit spot_url(@spot)
     click_on "投稿を編集", match: :first
 
@@ -64,7 +62,6 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should destroy Spot" do
-    sign_in @user
     visit spot_url(@spot)
 
     click_on "投稿を削除", match: :first

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -15,6 +15,7 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should create spot" do
+    sign_in @user
     visit spots_url
     click_on "新規投稿"
 
@@ -31,6 +32,7 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should update Spot" do
+    sign_in @user
     visit spot_url(@spot)
     click_on "投稿を編集", match: :first
 
@@ -47,6 +49,7 @@ class SpotsTest < ApplicationSystemTestCase
   end
 
   test "should destroy Spot" do
+    sign_in @user
     visit spot_url(@spot)
 
     click_on "投稿を削除", match: :first


### PR DESCRIPTION
## 作業内容
- [x] `edit.html.erb`のレイアウト修正
  - [x] 関連する`_spot.html.erb`のフォームの表示をわかりやすく修正
    - prefecture.nameが表示されるように
    - user.nameが表示されるように
- [x] `show.html.erb`のレイアウト修正
- [x] 関連する`_form.html.erb`のスタイルを修正
- [x] `user.rb`にログインユーザーの投稿か判別する`own?`メソッドを追記
- [x] `spots_controller.rb`をリファクタリング
  - [x] set_spotメソッドの仕様をログインユーザーの投稿のみ検索するように変更
## 備考