### PR TITLE
add:投稿詳細ページレイアウトやスタイルを調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,8 @@
         <span><%= alert %></span>
       </div>
     <% end %>
-    <div class="container mx-auto">
+
+    <div class="w-5/6 mx-auto max-w-screen-xl flex-grow mb-10">
       <%= yield %>
     </div>
 

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,30 +1,37 @@
 <div id="<%= dom_id spot %>">
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Name:</strong>
-    <%= spot.name %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Prefecture:</strong>
-    <%= spot.prefecture.name %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Address:</strong>
-    <%= spot.address %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Url:</strong>
-    <%= spot.url %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Body:</strong>
-    <%= spot.body %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">User:</strong>
-    <%= spot.user.name %>
-  </p>
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Image:</strong>
-    <%= image_tag spot.image.variant(resize_to_limit: [300, 300]) if spot.image.attached? %>
-  </p>
+  <!-- 画像部分 -->
+  <div>
+    <% if spot.image.attached? %>
+      <%= image_tag spot.image, class: "w-full" %>
+    <% end %>
+  </div>
+
+  <!-- 基本情報部分 -->
+  <div class="m-4 base-content bg-neutral">
+    <h2 class="bg-info text-info-content p-2">基本情報</h2>
+    <div class="ps-2">
+      <p class="my-5">
+        <strong class="block font-medium mb-1 text-base-content">位置情報</strong>
+        <%= spot.prefecture.name %> <%= spot.address %>
+      </p>
+
+      <p class="my-5">
+        <strong class="block font-medium mb-1 text-base-content">URL</strong>
+        <%= link_to spot.url, spot.url, target: "_blank", class: "text-primary underline" %>
+      </p>
+
+      <p class="my-5">
+        <strong class="block font-medium mb-1 text-base-content">投稿者名</strong>
+        <%= spot.user.name %>
+      </p>
+
+      <div class="mt-5">
+        <strong class="block font-medium mb-1 text-base-content sticky top-0">その他</strong>
+      </div>
+      <div class="overflow-y-auto max-h-48">
+        <%= simple_format(spot.body) %>
+      </div>
+
+    </div>
+  </div>
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,31 +1,29 @@
-<% content_for :title, "Showing spot" %>
+<% content_for :title, @spot.name %>
 
-<div class="md:w-2/3 w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+<!-- daisyUIのデフォルト通知
+<% if notice.present? %>
+  <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+<% end %>
+-->
+
+<h1 class="font-bold text-4xl p-4"><%= @spot.name%></h1>
+
+<%= render @spot %>
+
+<div class="flex w-3/5 flex-col border-opacity-50 mx-auto mt-5">
+  <% if current_user.own?(@spot) %>
+    <!-- button to edit a spot -->
+    <div class="card bg-base-content rounded-box grid place-items-center mb-5">
+      <%= link_to "投稿を編集", edit_spot_path(@spot), class: "btn btn-primary w-full" %>
+    </div>
+    <!-- button to delete a spot -->
+    <div class="card bg-base-content rounded-box grid place-items-center">
+      <%= link_to "投稿を削除", @spot, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error w-full" %>
+    </div>
+    <div class="divider">OR</div>
   <% end %>
 
-  <h1 class="font-bold text-4xl">Showing spot</h1>
-
-  <%= render @spot %>
-
-  <div class="flex w-3/5 flex-col border-opacity-50 mx-auto">
-    <% if current_user.own?(@spot) %>
-      <!-- button to edit a spot -->
-      <div class="card bg-base-300 rounded-box grid place-items-center mb-5">
-        <%= link_to "投稿を編集", edit_spot_path(@spot), class: "btn btn-primary w-full" %>
-      </div>
-      <!-- button to delete a spot -->
-      <div class="card bg-base-300 rounded-box grid place-items-center">
-        <%= link_to "投稿を削除", @spot, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error w-full" %>
-      </div>
-      <div class="divider">OR</div>
-    <% end %>
-
-    <div class="card bg-base-300 rounded-box grid place-items-center">
-      <%= link_to "投稿一覧に戻る", spots_path, class: "btn btn-primary w-full" %>
-    </div>
+  <div class="card bg-base-content rounded-box grid place-items-center">
+    <%= link_to "投稿一覧に戻る", spots_path, class: "btn btn-primary w-full" %>
   </div>
-
-
 </div>


### PR DESCRIPTION
# 作業内容
- [x] `show.html.erb`のレイアウトやスタイルを調整
  - [x] ページタイトルを動的に投稿の名前となるように
- [x] `_spot.html.erb`のレイアウトやスタイルを調整
  - [x] 投稿画像のlimitサイズ設定を撤廃
  - [x] 各項目を日本語化
  - [x] 基本情報をh2で配置
  - [x] 位置情報欄の内容では、都道府県名と詳細住所が併せて表示されるように
  - [x] URL欄の内容はリンク化（`link_to`へルパー）し、新規タブで開くように
  - [x] 投稿者欄には`user.name`が表示されるように
  - [x] その他欄の入力内容を改行できるようにsimple_formatを適用
- [x] `application.html.erb`のレイアウトやスタイルを調整
  - [x] 個別のviewファイルに対して以下の項目を適用
    - [x] 表示できる領域をページの`width`の`5/6`に
    - [x] 表示するコンテンツを中央揃え
    - [x] ページ全体がスクロールでき、常にfooterはページの下部に位置
    - [x] footerとの余白を常に一定に配置