### PR TITLE
add:投稿一覧ページに関するレイアウトやスタイルの調整

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -7,6 +7,13 @@ class Spot < ApplicationRecord
   validates :name, presence: true
   validates :address, presence: true
   validates :url, format: { with: URI.regexp(%w[http https]), message: "は有効なURL形式でなければなりません" }, allow_blank: true
+  validates :url, presence: true, if: :url_present?
   validates :body, length: { maximum: 5000 }
   validates :image, presence: true
+
+  private
+
+  def url_present?
+    url.present?
+  end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -6,7 +6,7 @@ class Spot < ApplicationRecord
 
   validates :name, presence: true
   validates :address, presence: true
-  validates :url, format: { with: /\Ahttps?:\/\/[^\s]+/i, message: "は有効なURL形式でなければなりません" }, allow_blank: true
+  validates :url, format: { with: /\Ahttps?:\/\/[^\s]+\z/i, message: "は有効なURL形式でなければなりません" }, allow_blank: true
   validates :url, presence: true, if: :url_present?
   validates :body, length: { maximum: 5000 }
   validates :image, presence: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -6,7 +6,7 @@ class Spot < ApplicationRecord
 
   validates :name, presence: true
   validates :address, presence: true
-  validates :url, format: { with: URI.regexp(%w[http https]), message: "は有効なURL形式でなければなりません" }, allow_blank: true
+  validates :url, format: { with: /\Ahttps?:\/\/[^\s]+/i, message: "は有効なURL形式でなければなりません" }, allow_blank: true
   validates :url, presence: true, if: :url_present?
   validates :body, length: { maximum: 5000 }
   validates :image, presence: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -7,5 +7,6 @@ class Spot < ApplicationRecord
   validates :name, presence: true
   validates :address, presence: true
   validates :url, format: { with: URI.regexp(%w[http https]), message: "は有効なURL形式でなければなりません" }, allow_blank: true
+  validates :body, length: { maximum: 5000 }
   validates :image, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
+  <body class="flex flex-col min-h-screen">
     <%= render 'shared/header' %>
 
     <!-- Notification -->

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,37 +1,17 @@
-<div id="<%= dom_id spot %>">
-  <!-- 画像部分 -->
-  <div>
-    <% if spot.image.attached? %>
-      <%= image_tag spot.image, class: "w-full" %>
-    <% end %>
-  </div>
+<div id="<%= dom_id spot %>" class="card col-span-1 bg-base-100 shadow-xl">
 
-  <!-- 基本情報部分 -->
-  <div class="m-4 base-content bg-neutral">
-    <h2 class="bg-info text-info-content p-2">基本情報</h2>
-    <div class="ps-2">
-      <p class="my-5">
-        <strong class="block font-medium mb-1 text-base-content">位置情報</strong>
-        <%= spot.prefecture.name %> <%= spot.address %>
-      </p>
+  <!-- カバー写真部分 -->
+  <figure>
+    <%= image_tag spot.image, class: "object-cover" %>
+  </figure>
 
-      <p class="my-5">
-        <strong class="block font-medium mb-1 text-base-content">URL</strong>
-        <%= link_to spot.url, spot.url, target: "_blank", class: "text-primary underline" %>
-      </p>
-
-      <p class="my-5">
-        <strong class="block font-medium mb-1 text-base-content">投稿者名</strong>
-        <%= spot.user.name %>
-      </p>
-
-      <div class="mt-5">
-        <strong class="block font-medium mb-1 text-base-content sticky top-0">その他</strong>
-      </div>
-      <div class="overflow-y-auto max-h-48">
-        <%= simple_format(spot.body) %>
-      </div>
-
+  <!-- 本文部分 -->
+  <div class="card-body">
+    <h2 class="card-title"><%= spot.name %></h2>
+    <p><%= spot.prefecture.name %><%= spot.address %></p>
+    <div class="card-actions justify-end">
+      <%= link_to "詳細", spot, class: "btn btn-primary" %>
     </div>
   </div>
+
 </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,24 +1,18 @@
 <% content_for :title, "Spots" %>
 
-<div class="w-full">
+<!-- 投稿一覧 -->
+  <!-- daisyUIデフォルトflash
   <% if notice.present? %>
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
   <% end %>
+  -->
 
-  <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Spots</h1>
-  </div>
-
-  <div id="spots" class="min-w-full">
-    <% if @spots.any? %>
-      <% @spots.each do |spot| %>
-        <%= render spot %>
-        <p>
-          <%= link_to "Show this spot", spot, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-        </p>
-      <% end %>
-    <% else %>
-      <p class="text-center my-10">No spots found.</p>
+<div class="grid sm:grid-cols-3 gap-5 md:gap-8">
+  <% if @spots.any? %>
+    <% @spots.each do |spot| %>
+      <%= render spot %>
     <% end %>
-  </div>
+  <% else %>
+    <p class="text-center my-10">投稿がありません</p>
+  <% end %>
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to nil, @spot.url, target: "_blank", class: "break-words" %>
+            <%= link_to h(@spot.url), h(@spot.url), target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to @spot.url, @spot.url, target: "_blank", class: "break-words" %>
+            <%= link_to sanitize(@spot.url), sanitize(@spot.url), target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to h(@spot.url), h(@spot.url), target: "_blank", class: "break-words" %>
+            <%= link_to nil, @spot.url, target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to sanitize(@spot.url), sanitize(@spot.url), target: "_blank", class: "break-words" %>
+            <%= link_to h(@spot.url), h(@spot.url), target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to Spot.find(params[:id]).url, Spot.find(params[:id]).url, target: "_blank", class: "break-words" %>
+            <%= link_to nil, Spot.find(params[:id]).url.to_s, target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -6,9 +6,48 @@
 <% end %>
 -->
 
-<h1 class="font-bold text-4xl p-4"><%= @spot.name%></h1>
+<h1 class="font-bold text-4xl p-3"><%= @spot.name%></h1>
+<div class="grid sm:grid-cols-3">
+  <figure class="sm:col-span-2 mb-3">
+    <%= image_tag @spot.image %>
+  </figure>
 
-<%= render @spot %>
+  <div class="bg-neutral sm:g sm:mx-4 w-full">
+    <h1 class="bg-info text-info-content p-4 text-xl">基本情報</h1>
+
+    <div class="py-5 mx-5">
+      <div class="divider divider-info text-info-content-0 text-lg">位置情報</div>
+      <div class="text-lg">
+        <%= @spot.prefecture.name %><%= @spot.address %>
+      </div>
+    </div>
+
+    <div class="py-5 mx-5">
+      <div class="divider divider-info text-xl">その他</div>
+      <% if @spot.body.present? %>
+        <div class="overflow-x-auto break-words max-h-48">
+          <%= simple_format(@spot.body) %>
+        </div>
+      <% else %>
+        <p class="text-base-content">情報がありません</p>
+      <% end %>
+    </div>
+
+    <div class="py-5 mx-5">
+      <div class="divider divider-info text-xl">公式サイト</div>
+      <div class="text-lg text-primary">
+        <% if @spot.url.present? %>
+          <div class="overflow-x-auto">
+            <%= link_to @spot.url, @spot.url, target: "_blank", class: "break-words" %>
+          </div>
+        <% else %>
+          <p class="text-base-content">情報がありません</p>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+</div>
 
 <div class="flex w-3/5 flex-col border-opacity-50 mx-auto mt-5">
   <% if current_user.own?(@spot) %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -38,7 +38,7 @@
       <div class="text-lg text-primary">
         <% if @spot.url.present? %>
           <div class="overflow-x-auto">
-            <%= link_to h(@spot.url), h(@spot.url), target: "_blank", class: "break-words" %>
+            <%= link_to Spot.find(params[:id]).url, Spot.find(params[:id]).url, target: "_blank", class: "break-words" %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>

--- a/test/controllers/spots_controller_test.rb
+++ b/test/controllers/spots_controller_test.rb
@@ -4,15 +4,23 @@ class SpotsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    # 動的にユーザーを作成（ユーザーのインデックスは `n` に基づく）
     @user = User.create!(
-      email: "user#{Time.now.to_i}0@example.com",  # この部分は動的に変更
+      email: "user#{Time.now.to_i}0@example.com",
       password: "password",
       name: "user0"
     )
 
     sign_in @user  # ログイン処理
-    @spot = Spot.create(name: "Test Spot", address: "Test Address", body: "Test Body", prefecture_id: 1, url: "http://example.com", user_id: @user.id, image: fixture_file_upload("test/fixtures/files/test_image.png", "image/png"))
+
+    @spot = Spot.create!(
+      name: "Test Spot",
+      address: "Test Address",
+      body: "Test Body",
+      prefecture_id: 1,
+      url: "http://example.com",
+      user_id: @user.id,
+      image: fixture_file_upload(Rails.root.join("test/fixtures/files/test_image.png"), "image/png")
+    )
   end
 
   test "should get index" do
@@ -27,7 +35,7 @@ class SpotsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create spot" do
     assert_difference("Spot.count") do
-      post spots_url, params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url, image: fixture_file_upload("test/fixtures/files/test_image.png", "image/png") } }
+      post spots_url, params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url, image: fixture_file_upload(Rails.root.join("test/fixtures/files/test_image.png"), "image/png") } }
     end
 
     assert_redirected_to spot_url(Spot.last)
@@ -44,7 +52,7 @@ class SpotsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update spot" do
-    patch spot_url(@spot), params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url, image: fixture_file_upload("test/fixtures/files/test_image.png", "image/png") } }
+    patch spot_url(@spot), params: { spot: { address: @spot.address, body: @spot.body, name: @spot.name, prefecture_id: @spot.prefecture_id, url: @spot.url, image: fixture_file_upload(Rails.root.join("test/fixtures/files/test_image.png"), "image/png") } }
     assert_redirected_to spot_url(@spot)
   end
 

--- a/test/fixtures/spots.yml
+++ b/test/fixtures/spots.yml
@@ -1,17 +1,18 @@
-one:
-  name: "Test Spot"
-  address: "Test Address"
-  body: "Test Body"
-  prefecture_id: 1
-  url: "http://example.com"
-  user: user_0
-  image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>
+# testにて直接生成する形式にへんこうしたためコメントアウト
+# one:
+#   name: "Test Spot"
+#   address: "Test Address"
+#   body: "Test Body"
+#   prefecture_id: 1
+#   url: "http://example.com"
+#   user: user_0
+#   image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>
 
-two:
-  name: "Another Spot"
-  address: "Another Address"
-  body: "Another Body"
-  prefecture_id: 1
-  url: "http://example.com"
-  user: user_1
-  image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>
+# two:
+#   name: "Another Spot"
+#   address: "Another Address"
+#   body: "Another Body"
+#   prefecture_id: 1
+#   url: "http://example.com"
+#   user: user_1
+#   image: <%= Rails.root.join("test/fixtures/files/test_image.png") %>

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -27,7 +27,7 @@ class SpotsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit spots_url
-    assert_selector "h1", text: "Spots"
+    assert_selector "h2", text: "Spots"
   end
 
   test "should create spot" do

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -27,7 +27,7 @@ class SpotsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit spots_url
-    assert_selector "h2", text: "Spots"
+    assert_selector "h2", text: @spot.name
   end
 
   test "should create spot" do

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -12,14 +12,14 @@ class SpotsTest < ApplicationSystemTestCase
 
     sign_in @user  # ログイン処理
 
-    prefecture = Prefecture.find_by(name: "東京都") || Prefecture.create!(name: "東京都", region: 2)
+    # prefecture = Prefecture.find_by(name: "東京都") || Prefecture.create!(name: "東京都", region: 2)
 
     @spot = Spot.create!(
       name: "テストスポット",
-      address: "東京都新宿区",
+      address: "新宿区内藤町１１",
       url: "https://example.com",
       body: "テスト用のスポットです。",
-      prefecture_id: prefecture.id,
+      prefecture_id: 13,
       user: @user,
       image: Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test_image.png"), "image/png")
     )


### PR DESCRIPTION
# 作業内容
- [x] `index.html.erb`のレイアウトやスタイルの調整
  - [x] spotがcard形式で表示されるように調整
- [x] `show.html.erb`のレイアウトやスタイルの調整
  - [x] spotがgridシステムで表示されるように調整
  - [x] bodyカラムについて以下のように調整
    - [x] 長すぎるテキストはスクロールできるように
    - [x] 表示される最大高さを指定
    - [x] コンテンツがはみ出さないように折り返し指定
  - [x] 空入力の場合に「情報がありません」と表示されるように制御分を配置
- [x] spot.rbのbodyにlengthが5000になるようにvalidatesを追記
- [x] `application.html.erb`にてfooterが下部に固定されるように指定