### PR TITLE
fix:新規投稿時に画像を付加すると出るエラー修正

### DIFF
--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -40,7 +40,7 @@
     <%= form.label :image, "画像", class: "label" %>
     <%= form.file_field :image, class: ["file-input file-input-bordered file-input-primary w-full mt-2", {"border-gray-400": spot.errors[:image].none?, "border-red-400": spot.errors[:image].any?}] %>
 
-    <% if spot.image.attached? %>
+    <% if @spot.persisted? && @spot.image.attached? %>
       <div class="mt-3">
         <%= image_tag spot.image.variant(resize_to_limit: [300, 300]) %>
       </div>


### PR DESCRIPTION
# 作業衣用
- 新規投稿時に画像以外の必須パラメータが不足していると発生するエラーの解決
  - `_form.html.erb`の修正
    - [x] 投稿された画像のプレビューについて、`@spot.persisted?`を条件分岐に論理積として追記