### PR TITLE
add:Google Analyticsの導入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YX6C9JVDVW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-YX6C9JVDVW');
+    </script>
+
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
# 作業内容
## Google Analyticsの設定
- [x] ログインし、アカウント名設定などを行う
## Railsでの設定
- [x] `app/views/layouts/application.html.erb` ファイルの <head> 内にトラッキングコードを貼り付け
# 備考
- [Google Analytics(GA4) の導入から特定IPアドレスの除外まで【Rails】](https://qiita.com/kzkio/items/109609584eaa61cd44d6)