### PR TITLE
add:CI用のディレクトリとファイルを生成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
+        # RSpecに要変更
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests


### PR DESCRIPTION
# 作業内容
- [x] GitHub CI/CD実践ガイドを読みCIについて学習
- [x] CIを適用するディレクトリとファイルを作成
```bash
touch .github/workflows/ci.yml
```
# 備考
- [GitHub CI/CD実践ガイド](https://gihyo.jp/book/2024/978-4-297-14173-8)