### PR TITLE
add:検索機能（ransack）追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "ruby-vips"
 # メタタグ
 gem "meta-tags"
 
+# 検索機能（ransack）
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "ruby-vips"
 gem "meta-tags"
 
 # 検索機能（ransack）
-gem 'ransack'
+gem "ransack"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.11.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -384,6 +388,7 @@ DEPENDENCIES
   pry
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
+  ransack
   rubocop-rails-omakase
   ruby-vips
   selenium-webdriver

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,7 +4,10 @@ class SpotsController < ApplicationController
 
   # GET /spots or /spots.json
   def index
-    @spots = Spot.includes(:user, :prefecture)
+    @q = Spot.ransack(params[:q])
+    @spots = @q.result.includes(:user, :prefecture)
+    # 都道府県の選択肢を取得
+    @prefectures = Prefecture.all
   end
 
   # GET /spots/1 or /spots/1.json

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -18,11 +18,11 @@ class Spot < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["address", "body", "name", "prefecture_id", "updated_at", "user_id", "use.name"]
+    [ "address", "body", "name", "prefecture_id", "updated_at", "user_id", "use.name" ]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    ["user", "prefecture"]
+    [ "user", "prefecture" ]
   end
 
   # ransacker :user_name, formatter: proc { |v| User.where("name LIKE ?", "%#{v}%").pluck(:id) } do |parent|

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -16,4 +16,16 @@ class Spot < ApplicationRecord
   def url_present?
     url.present?
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["address", "body", "name", "prefecture_id", "updated_at", "user_id", "use.name"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["user", "prefecture"]
+  end
+
+  # ransacker :user_name, formatter: proc { |v| User.where("name LIKE ?", "%#{v}%").pluck(:id) } do |parent|
+  #   parent.table[:user_id]
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,8 @@ class User < ApplicationRecord
   def own?(object)
     id == object&.user.id
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["id", "name"]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,6 @@ class User < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["id", "name"]
+    [ "id", "name" ]
   end
 end

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -1,0 +1,23 @@
+<div class="mb-8 max-w-3xl mx-auto">
+  <%= search_form_for @q, class: "w-full grid grid-cols-6 gap-4" do |f| %>
+    <div class="col-span-2">
+      <%= f.label :prefecture_id_eq, "都道府県", class: "label" %>
+      <%= f.select :prefecture_id_eq, options_from_collection_for_select(@prefectures, :id,  :name, params.dig(:q, :prefecture_id_eq)),
+      { include_blank: "選択してください" },
+      { class: "w-full select select-bordered" } %>
+    </div>
+
+    <div class="col-span-4">
+      <%= f.label :name_or_address_or_body_or_user_name, "キーワード検索", class: "label" %>
+      <%= f.search_field :name_or_address_or_body_or_user_name, placeholder: "キーワードを入力", class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="col-span-5">
+      <%= f.submit "検索", class: "btn btn-primary w-full" %>
+    </div>
+
+    <div class="col-span-1">
+      <%= sort_link(@q, :update_at, default_order: :desc, class: "btn btn-outline w-full") %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -7,6 +7,8 @@
   <% end %>
   -->
 
+<%= render 'search_form', q: @q, url: spots_path %>
+
 <div class="grid sm:grid-cols-3 gap-5 md:gap-8">
   <% if @spots.any? %>
     <% @spots.each do |spot| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,10 @@ Rails.application.routes.draw do
     root to: "top#home"
   end
 
+  resources :spots
+
   # 利用規約
   get "terms", to: "terms#index"
-
-  resources :spots
 
   devise_for :users
 end


### PR DESCRIPTION
# 作業内容

## 実装
### Gem
Gemfile
- [x] `Gemfile`にgemを追記（ransack）

### bash
- [x]  `bundle install`

### controller
- `index`アクションを編集
- [x] `app/controllers/spots_controller.rb`を編集
  - [x] インスタンス変数に処理内容を代入

### model
- `Spot` モデルを編集
  - [x] 検索可能なカラムを明示的に記述（self.ransackable_attributesメソッド）
    - [x] 以下のカラムを使用対象に指定
    ```ryby
    ["address", "body", "name", "prefecture_id", "updated_at", "user_id", "use.name"]
    ```
  - 【メモ】`"user_id", "use.name"`は、関連するUserモデルにアクセスするために必要であり、それを記述
  - 検索可能なカラムを持つ関連付けられたモデルを明示的に記述（self.ransackable_associations）

- `User`モデルを編集
  - 検索可能なカラムを明示的に記述（self.ransackable_attributesメソッド）
    - [x] 以下のカラムを使用対象に指定
    ```ryby
    ["id", "name"]
    ```

### view
bash
  - [x]  ファイルを生成
  ```sh
  touch app/views/spots/_search_form.html.erb
  ```
viewファイルを編集
- `app/views/spots/_search_form.html.erb`を編集
  - [x] 検索フォームを構築
  - [x] 検索フォームのスタイルを調整
-  `app/views/boards/index.html.erb`を編集
  - [x] 検索フォームがレンダリングされるように記述

# 備考
- [gem ransack](https://github.com/activerecord-hackery/ransack?tab=readme-ov-file)
- [ransack Docs](https://activerecord-hackery.github.io/ransack/)