### PR TITLE
add:i18nを適用

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "meta-tags"
 # 検索機能（ransack）
 gem "ransack"
 
+# I18n
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -388,6 +391,7 @@ DEPENDENCIES
   pry
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
+  rails-i18n
   ransack
   rubocop-rails-omakase
   ruby-vips

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -30,10 +30,10 @@ class SpotsController < ApplicationController
 
     respond_to do |format|
       if @spot.save
-        format.html { redirect_to @spot, notice: "Spot was successfully created." }
+        format.html { redirect_to @spot, notice: t("spots.create.success") }
         format.json { render :show, status: :created, location: @spot }
       else
-        format.html { render :new, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_entity, notice: t("spots.create.failure") }
         format.json { render json: @spot.errors, status: :unprocessable_entity }
       end
     end
@@ -43,10 +43,10 @@ class SpotsController < ApplicationController
   def update
     respond_to do |format|
       if @spot.update(spot_params)
-        format.html { redirect_to @spot, notice: "Spot was successfully updated." }
+        format.html { redirect_to @spot, notice: t("spots.update.success") }
         format.json { render :show, status: :ok, location: @spot }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_entity, notice: t("spots.update.failure") }
         format.json { render json: @spot.errors, status: :unprocessable_entity }
       end
     end
@@ -57,7 +57,7 @@ class SpotsController < ApplicationController
     @spot.destroy!
 
     respond_to do |format|
-      format.html { redirect_to spots_path, status: :see_other, notice: "Spot was successfully destroyed." }
+      format.html { redirect_to spots_path, status: :see_other, notice: t("spots.destroy.success") }
       format.json { head :no_content }
     end
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -48,7 +48,7 @@
             <div class="card bg-base-300 rounded-box grid place-items-center">
               <!-- サインアップボタン -->
               <div class="form-control w-full">
-                <%= f.submit t('helpers.submit.create'), class: "btn btn-primary w-full" %>
+                <%= f.submit t('devise.registrations.new.submit'), class: "btn btn-primary w-full" %>
               </div>
             </div>
             <div class="divider">OR</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="hero bg-base-200 min-h-screen">
   <div class="hero-content flex-col w-full">
     <div class="text-center lg:text-left mb-5">
-      <h1 class="text-5xl font-bold">新規会員登録</h1>
+      <h1 class="text-5xl font-bold"><%= t('.title') %></h1>
     </div>
 
     <div class="card bg-base-100 w-full max-w-sm shrink-0 shadow-2xl">
@@ -12,7 +12,7 @@
           <!-- 名前フィールド -->
           <div class="form-control">
             <label class="label">
-              <span class="label-text">名前</span>
+              <span class="label-text"><%= t('helpers.label.name') %></span>
             </label>
             <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered", required: true %>
           </div>
@@ -20,7 +20,7 @@
           <!-- メールアドレスフィールド -->
           <div class="form-control">
             <label class="label">
-              <span class="label-text">メールアドレス</span>
+              <span class="label-text"><%= t('helpers.label.email') %></span>
             </label>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered" %>
           </div>
@@ -28,7 +28,7 @@
           <!-- パスワードフィールド -->
           <div class="form-control">
             <label class="label">
-              <span class="label-text">パスワード</span>
+              <span class="label-text"><%= t('helpers.label.password') %></span>
             </label>
             <% if @minimum_password_length %>
             <em>(<%= @minimum_password_length %> 文字以上必要です)</em>
@@ -39,7 +39,7 @@
           <!-- パスワード確認フィールド -->
           <div class="form-control">
             <label class="label">
-              <span class="label-text">パスワード確認</span>
+              <span class="label-text"><%= t('helpers.label.password_confirmation') %></span>
             </label>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered" %>
           </div>
@@ -48,12 +48,12 @@
             <div class="card bg-base-300 rounded-box grid place-items-center">
               <!-- サインアップボタン -->
               <div class="form-control w-full">
-                <%= f.submit "登録する", class: "btn btn-primary w-full" %>
+                <%= f.submit t('helpers.submit.create'), class: "btn btn-primary w-full" %>
               </div>
             </div>
             <div class="divider">OR</div>
             <div class="card bg-base-300 rounded-box grid place-items-center">
-              <%= link_to "ログインの場合", new_user_session_path, class: "btn btn-primary w-full" %>
+              <%= link_to t('.to_login_page'), new_user_session_path, class: "btn btn-primary w-full" %>
             </div>
           </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,15 @@
 <footer class="footer footer-center bg-base-200 text-base-content rounded p-10 mt-12">
   <nav class="grid grid-flow-col gap-4">
-    <%= link_to "お問い合わせ", "https://forms.gle/PSBY2iA6keoDJm416",
+    <%= link_to t('footer.contact'), "https://forms.gle/PSBY2iA6keoDJm416",
                 class: "link link-hover",
                 target: "_blank",
                 rel: "noopener noreferrer" %>
-    <%= link_to "利用規約", terms_path, class: "link link-hover" %>
-    <%= link_to "プライバシーポリシー", "https://kiyac.app/privacypolicy/qO1wEtf0KvWQzyLaRJGK", class: "link link-hover", target: "_blank", rel: "noopener noreferrer" %>
+    <%= link_to t('footer.terms'), terms_path,
+                class: "link link-hover" %>
+    <%= link_to t('footer.privacy_policy'), "https://kiyac.app/privacypolicy/qO1wEtf0KvWQzyLaRJGK",
+                class: "link link-hover",
+                target: "_blank",
+                rel: "noopener noreferrer" %>
   </nav>
   <nav>
     <div class="grid grid-flow-col gap-4">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,21 +6,21 @@
     <ul class="menu menu-horizontal px-1">
       <% if user_signed_in? %>
         <li>
-          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+          <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete } %>
         </li>
       <% else %>
         <li>
-          <%= link_to "サインアップ", new_user_registration_path %>
+          <%= link_to t('header.sign_up'), new_user_registration_path %>
         </li>
         <li>
-          <%= link_to "ログイン", new_user_session_path %>
+          <%= link_to t('header.login'), new_user_session_path %>
         </li>
       <% end %>
       <li>
-        <%= link_to "新規投稿", new_spot_path %>
+        <%= link_to t('header.create_spot'), new_spot_path %>
       </li>
       <li>
-        <%= link_to "検索する", spots_path %>
+        <%= link_to t('header.spot_index'), spots_path %>
       </li>
     </ul>
   </div>

--- a/app/views/top/home.html.erb
+++ b/app/views/top/home.html.erb
@@ -6,7 +6,7 @@
   <div class="hero-content text-neutral-content text-center">
     <div class="max-w-3xl">
       <h1 class="mb-5 text-5xl font-bold">心に残る夜景を、ここで見つけよう</h1>
-      <%= link_to "夜景スポットを探す", spots_path, class: "btn btn-primary" %>
+      <%= link_to t('top.home.search_spots'), spots_path, class: "btn btn-primary" %>
     </div>
   </div>
 </div>
@@ -53,12 +53,12 @@
   <div class="flex w-3/5 flex-col border-opacity-50">
     <!-- button for user registration -->
     <div class="card bg-base-300 rounded-box grid place-items-center">
-      <%= link_to "新規会員登録", new_user_registration_path, class: "btn btn-primary w-full" %>
+      <%= link_to t('top.home.to_registration_page'), new_user_registration_path, class: "btn btn-primary w-full" %>
     </div>
     <div class="divider">OR</div>
     <!-- button for login -->
     <div class="card bg-base-300 rounded-box grid place-items-center">
-      <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary w-full" %>
+      <%= link_to t('top.home.to_login_page'), new_user_session_path, class: "btn btn-primary w-full" %>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      spot: スポット
+    attributes:
+      user:
+        email: メールアドレス
+        name: ユーザー名
+        password: パスワード
+        password_confirmation: パスワード確認
+      spot:
+        name: スポット名
+        address: 位置情報
+        url: URL
+        body: その他情報
+        image: 画像

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -2,7 +2,7 @@ ja:
   # フォームへルパー関係は以下から取得する
   helpers:
     submit:
-      create: 登録
+      create: 投稿
       submit: 保存
       update: 更新
     label:
@@ -34,6 +34,7 @@ ja:
       destroyed: アカウントを削除しました。
       new:
         title: 新規会員登録
+        submit: 登録
         to_login_page: ログインページへ
         to_register_page: 登録ページへ
         password_forget: パスワードをお忘れの方はこちら

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,70 @@
+ja:
+  # フォームへルパー関係は以下から取得する
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      name: ユーザー名
+      email: メールアドレス
+      password: パスワード
+      password_confirmation: パスワード確認
+  top:
+    home:
+      search_spots: 夜景スポットを探す
+      to_registration_page: 新規会員登録ページへ
+      to_login_page: ログインページへ
+  devise:
+    failure:
+      unauthenticated: ログインが必要です。
+      unconfirmed: メールアドレスの確認が必要です。
+      locked: アカウントがロックされています。
+      invalid: メールアドレスまたはパスワードが違います。
+      timeout: セッションの有効期限が切れました。
+    sessions:
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    passwords:
+      send_instructions: パスワードリセットの案内を送信しました。
+      updated: パスワードが変更されました。
+    registrations:
+      signed_up: アカウント登録が完了しました。
+      updated: アカウント情報を更新しました。
+      destroyed: アカウントを削除しました。
+      new:
+        title: 新規会員登録
+        to_login_page: ログインページへ
+        to_register_page: 登録ページへ
+        password_forget: パスワードをお忘れの方はこちら
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      password_forget: パスワードをお忘れの方はこちら
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  spots:
+    create:
+      success: 投稿が作成されました
+      failure: 投稿できませんでした
+    update:
+      success: 投稿が更新されました
+      failure: 更新できませんでした
+    destroy:
+      success: 削除されました
+  header:
+    sign_up: 新規登録
+    login: ログイン
+    logout: ログアウト
+    spot: スポット
+    spot_index: 投稿一覧
+    create_spot: 新規投稿
+    # bookmark_index: ブックマーク一覧
+    # profile: プロフィール
+  footer:
+    contact: お問い合わせ
+    terms: 利用規約
+    privacy_policy: プライバシーポリシー

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -40,9 +40,9 @@ class SpotsTest < ApplicationSystemTestCase
     select @spot.prefecture.name, from: "spot[prefecture_id]"
     fill_in "spot_url", with: @spot.url
     attach_file "spot_image", Rails.root.join("test/fixtures/files/test_image.png")
-    click_on "Create Spot"
+    click_on "投稿"
 
-    assert_text "Spot was successfully created"
+    assert_text "投稿が作成されました"
     click_on "投稿一覧に戻る"
   end
 
@@ -56,9 +56,9 @@ class SpotsTest < ApplicationSystemTestCase
     select @spot.prefecture.name, from: "spot[prefecture_id]"
     fill_in "spot_url", with: @spot.url
     attach_file "spot_image", Rails.root.join("test/fixtures/files/test_image.png")
-    click_on "Update Spot"
+    click_on "更新"
 
-    assert_text "Spot was successfully updated"
+    assert_text "投稿が作成されました"
     click_on "投稿一覧に戻る"
   end
 
@@ -69,6 +69,6 @@ class SpotsTest < ApplicationSystemTestCase
       click_on "投稿を削除", match: :first
     end
 
-    assert_text "Spot was successfully destroyed"
+    assert_text "削除されました"
   end
 end

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -58,7 +58,7 @@ class SpotsTest < ApplicationSystemTestCase
     attach_file "spot_image", Rails.root.join("test/fixtures/files/test_image.png")
     click_on "更新"
 
-    assert_text "投稿が作成されました"
+    assert_text "投稿が更新されました"
     click_on "投稿一覧に戻る"
   end
 


### PR DESCRIPTION
# 作業内容
## Railsのi18nのデフォルト設定を :ja にする
### `config/application.rb`
- [x]  以下を追記
```ruby
config.i18n.default_locale = :ja
```
Railsアプリケーションのデフォルトの言語設定が日本語（:ja）に設定される。

## install
### `Gemfile`
- [x]  `gem “rails-i18n”`を記述
- [x]  Dockerを立ち上げ設定を適用

## `config/locales/activerecord/ja.yml`
### rails_i18n に使用するディレクトリ、ファイルの生成
- [x]  以下を実行を生成
```bash
mkdir config/locales/activerecord
touch config/locales/activerecord/ja.yml
```

## `config/locales/views/ja.yml`
### rails_i18n に使用するディレクトリ、ファイルの生成
- [x]  以下を実行を生成
```bash
mkdir config/locales/views
touch config/locales/views/ja.yml
```

## 該当ビューの日本語部分をi18n対応する
### header
- [x] `app/views/shared/_header.html.erb`を編集
### footer
- [x] `app/views/shared/_header.html.erb`を編集
### TOPページ
- [x] `app/views/top/home.html.erb`を編集
### 新規会員登録（devise）
- [x] `app/views/devise/registrations/new.html.erb`を編集
### spots_controller
- [x] `app/controllers/spots_controller.rb`を編集
## 翻訳ファイルに追記
- [x] `views/ja.yml`を編集
- [x] `config/locales/activerecord/ja.yml`を編集