### PR TITLE
fix:投稿一覧ページにI18nを適用

### DIFF
--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -15,6 +15,6 @@
       <%= render spot %>
     <% end %>
   <% else %>
-    <p class="text-center my-10">投稿がありません</p>
+    <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
   <% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -48,6 +48,8 @@ ja:
       title: ユーザー登録
       to_login_page: ログインページへ
   spots:
+    index:
+      no_spots: 条件に合うスポットが見つかりませんでした
     create:
       success: 投稿が作成されました
       failure: 投稿できませんでした


### PR DESCRIPTION
# 作業内容
## I18nやフラッシュに関わるスタイルを編集
### `spots/index.html.erb`を編集
  - [ ] 検索に合致しなかった場合のI18nを表示するように変更
### `views/ja.yml`を編集
  - [ ] 翻訳部を追記