### PR TITLE
add:キーワード検索が正常に動作するように

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,6 +4,10 @@ class SpotsController < ApplicationController
 
   # GET /spots or /spots.json
   def index
+    # 検索条件をparamsから取り出して手動でマージ
+    search_params = params[:q] || {}
+    search_params[:name_or_address_or_body_or_user_name_cont] = params[:q][:name_or_address_or_body_or_user_name] if params.dig(:q, :name_or_address_or_body_or_user_name).present?
+
     @q = Spot.ransack(params[:q])
     @spots = @q.result.includes(:user, :prefecture).page(params[:page])
     # 都道府県の選択肢を取得

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -2,7 +2,7 @@
   <%= search_form_for @q, class: "w-full grid grid-cols-6 gap-4" do |f| %>
     <div class="col-span-2">
       <%= f.label :prefecture_id_eq, "都道府県", class: "label" %>
-      <%= f.select :prefecture_id_eq, options_from_collection_for_select(@prefectures, :id,  :name, params.dig(:q, :prefecture_id_eq)),
+      <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,
       { include_blank: "選択してください" },
       { class: "w-full select select-bordered" } %>
     </div>


### PR DESCRIPTION
# 作業内容
## エラー特定
- params[:q][:name_or_address_or_body_or_user_name_cont]の値が無効になっていた。
## 修正
- `app/controllers/spots_controller.rb`を編集
  - indexアクション
    - [x] 無効になっている「キーワード検索」入力部分を手動で値を代入