### PR TITLE
add:gコマンドの自動生成を制限

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,11 @@ module Myapp
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.i18n.default_locale = :ja
+
+    config.generators.system_tests = nil
+    config.generators do |g|
+      g.skip_routes true
+      g.test_framework nil
+    end
   end
 end


### PR DESCRIPTION
## 作業内容
### rails g コマンドを編集
- `config/application.rb`を編集
  - [x] システムテストを非生成に
  - [x] ルーティングの記述を加えないように
  - [x] テストフレームワークを使わないように