### PR TITLE
add:検索結果のturbo化

### DIFF
--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-8 mt-4 max-w-3xl mx-auto">
-  <%= search_form_for @q, class: "w-full grid grid-cols-6 gap-4" do |f| %>
+  <%= search_form_for @q, html: { data: { turbo_frame: "spots_list" } }, class: "w-full grid grid-cols-6 gap-4" do |f| %>
     <div class="col-span-2">
       <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,
       { include_blank: "都道府県を選択" },

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,22 +1,17 @@
 <% content_for :title, "Spots" %>
 
-<!-- 投稿一覧 -->
-  <!-- daisyUIデフォルトflash
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-  -->
-
 <%= render 'search_form', q: @q, url: spots_path %>
 
-<div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
-  <% if @spots.any? %>
-    <% @spots.each do |spot| %>
-      <%= render spot %>
+<%= turbo_frame_tag "spots_list" do %>
+  <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8", id="spots_list">
+    <% if @spots.any? %>
+      <% @spots.each do |spot| %>
+        <%= render spot %>
+      <% end %>
+    <% else %>
+      <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
     <% end %>
-  <% else %>
-    <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
-  <% end %>
-</div>
+  </div>
 
-<%= paginate @spots %>
+  <%= paginate @spots %>
+<% end %>


### PR DESCRIPTION
# 作業内容

## 概要

- 検索機能に対して`Turbo Frames`を適用し、UXの向上を図る。
- 検索時に画面全体を更新するのではなく、検索結果となる一覧部分だけ更新する。

## turbo_frameオプションを適用する

- [x]  以下のようにturbo_frame化する

検索フォームのビューファイル（`app/views/spots/_search_form.html.erb`）に適用

変更前

```html
<%= search_form_for @q, class: "w-full grid grid-cols-6 gap-4" do |f| %>
```

↓

```html
<%= search_form_for @q, html: { data: { turbo_frame: "spots-list" } } do |f| %>
```

## turbo_frame_tagを対象のタグに適用

- [x]  以下の変更する部分を`turbo_frame_tag`で囲む
- `app/views/spots/index.html.erb` を編集

```html
<% content_for :title, "Spots" %>

<!-- 投稿一覧 -->
<%= render 'search_form', q: @q, url: spots_path %>

<%= turbo_frame_tag "spots_list" do %>
  <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8", id="spots_list">
    <% if @spots.any? %>
      <% @spots.each do |spot| %>
        <%= render spot %>
      <% end %>
    <% else %>
      <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
    <% end %>
  </div>

  <%= paginate @spots %>
<% end %>
```

# 備考

- https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-2#%E6%A4%9C%E7%B4%A2%E3%81%AEturbo-frames%E5%8C%96
- https://qiita.com/kumaryoya/items/035db004b0dcf3cab04e