### PR TITLE
add:コメントを削除できるように

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
-  before_action :set_spot
+  before_action :set_spot, only: %i[create destroy]
+  before_action :set_comment, only: %i[destroy]
 
   def create
     @comment = @spot.comments.new(comment_params)
@@ -12,13 +13,31 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    spot = Spot.find(params[:spot_id])
+    comment = spot.comments.find(params[:id])
+    if comment.user.id == current_user.id
+      if comment.destroy
+        redirect_to spot, notice: "コメントが削除されました。"
+      else
+        redirect_to spot, alert: "コメントの削除に失敗しました。"
+      end
+    else
+      redirect_to spot, alert: "他のユーザーのコメントは削除できません。"
+    end
+  end
+
   private
 
   def set_spot
     @spot = Spot.find(params[:spot_id])
   end
 
+  def set_comment
+    @comment = @spot.comments.find(params[:id])
+  end
+
   def comment_params
-    params.require(:comment).permit(:body)
+    params.require(:comment).permit(:body).merge(spot_id: params[:spot_id])
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,15 @@
 <div class="comment">
-  <p><strong><%= comment.user.name %></strong> - <%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></p>
-  <p><%= comment.body %></p>
+  <table class="comment-table mb-4">
+    <tr>
+      <td><strong><%= comment.user.name %></strong></td>
+      <td><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+    </tr>
+    <tr>
+      <td colspan="2"><%= comment.body %></td>
+    </tr>
+  </table>
+  <% if current_user&.own?(comment) %>
+    <%= link_to "コメントを削除", spot_comment_path(comment.spot, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-error w-full" %>
+  <% end %>
+  <div class="divider"></div>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,10 +1,9 @@
 <%= form_with model: comment, url: spot_comments_path(spot), class: 'w-full' do |f| %>
   <div class="form-control mb-4">
-    <%= f.label :body, t('helpers.label.comment'), class: 'label-text' %>
-    <%= f.text_area :body, class: 'textarea textarea-bordered w-full', rows: 4 %>
+    <%= f.text_area :body, class: 'textarea textarea-bordered w-full', placeholder: "コメントを入力", rows: 3 %>
   </div>
 
   <div class="form-control mb-4">
-    <%= f.submit t('helpers.submit.create'), class: 'btn btn-primary w-full' %>
+    <%= f.submit t('helpers.submit.comment_create'), class: 'btn btn-primary w-full' %>
   </div>
 <% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -60,10 +60,12 @@
 <div class="flex w-3/5 flex-col mx-auto my-8">
   <%= render 'comments/form', comment: @comment, spot: @spot %>
 
+  <div class="divider"></div>
+
   <% if @spot.comments.any? %>
     <%= render @spot.comments %>
   <% else %>
-    <p class="mx-auto">コメントはまだありません。</p>
+    <p class="mx-auto">コメントはまだ投稿されていません</p>
   <% end %>
 </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
   helpers:
     submit:
       create: 投稿
+      comment_create: コメントを投稿
       submit: 保存
       update: 更新
       send: 送信

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :spots do
-    resources :comments, only: %i[ create ], shallow: true
+    resources :comments, only: %i[ create destroy ]
     resource :bookmarks, only: %i[ create destroy ]
   end
 


### PR DESCRIPTION
# 作業内容
## ルーティング
- [x] `routes.rb`を以下のように編集
  - `Comment`リソースのルートに`destroy`アクションを追記
  - `shallow: true`を解除
## commentsコントローラー
- [x] `comments_controller.rb`を以下のように編集
  - `destroy`アクションを追記
  - コメントしたユーザーと削除しようとしているユーザーのIDが同一か条件制御
  - コメント削除処理を追記
## viewの編集
- [x] `show.html.erb`を編集
  - コメント欄との境界線を追加
- [x] `_form.html.erb`を編集
  - placehoderを追記
- [x] `_comment.html.erb`を編集
  - コメント欄を調整
  - コメント投稿ユーザーにしか削除リンクをクリックできないように
## `ja.yml`
- [x] ボタンなどのビューの翻訳を追加
# 備考