### PR TITLE
Feature/turbolize destroy comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,10 +15,13 @@ class CommentsController < ApplicationController
 
   def destroy
     spot = Spot.find(params[:spot_id])
-    comment = spot.comments.find(params[:id])
-    if comment.user.id == current_user.id
-      if comment.destroy
-        redirect_to spot, notice: "コメントが削除されました。"
+    @comment = spot.comments.find(params[:id])
+
+    if @comment.user.id == current_user.id
+      if @comment.destroy
+        respond_to do |format|
+          format.turbo_stream
+        end
       else
         redirect_to spot, alert: "コメントの削除に失敗しました。"
       end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment">
+<div id="comment_<%= comment.id %>" class="comment">
   <table class="comment-table mb-4">
     <tr>
       <td><strong><%= comment.user.name %></strong></td>
@@ -9,7 +9,7 @@
     </tr>
   </table>
   <% if current_user&.own?(comment) %>
-    <%= link_to "コメントを削除", spot_comment_path(comment.spot, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-error w-full" %>
+    <%= link_to "削除する", spot_comment_path(comment.spot, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-error w-full" %>
   <% end %>
   <div class="divider"></div>
 </div>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove comment %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.remove comment %>
+<%= turbo_stream.remove @comment %>


### PR DESCRIPTION
# 作業内容
## `destroy.turbo_stream.erb`の作成と編集
- [x] 以下を実行
```
touch app/views/comments/destroy.turbo_stream.erb
```
- [x] 以下の内容を記述
  - 指定したIDのコメントを非同期で削除
## コントローラーの編集
- [x] `comments_controller.rb`を以下のように編集
  - `destroy`アクションに`turbo_stream`のformatの場合の処理を記述
## ビューの編集
- [x] `app/views/comments/_comment.html.erb`を編集
  - 全体を囲んだ要素に対して、`comment_id`を設定
# 備考
- [猫でもわかるHotwire入門 Turbo編](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-2#%E5%89%8A%E9%99%A4%E3%81%AEturbo-streams%E5%8C%96)
- [Rails7でTurboを理解しよう！](https://zenn.dev/jack_javis123/books/4956e8a79b407c/viewer/ae5e52)