### PR TITLE
Feature/comment edit

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,9 @@
 class CommentsController < ApplicationController
-  before_action :set_spot, only: %i[create destroy]
-  before_action :set_comment, only: %i[destroy]
+  before_action :set_spot, only: %i[edit create update destroy]
+  before_action :set_comment, only: %i[edit update destroy]
+
+  def edit
+  end
 
   def create
     @comment = @spot.comments.new(comment_params)
@@ -13,10 +16,15 @@ class CommentsController < ApplicationController
     end
   end
 
-  def destroy
-    spot = Spot.find(params[:spot_id])
-    @comment = spot.comments.find(params[:id])
+  def update
+    if @comment.update(comment_params)
+      redirect_to @spot, notice: "コメントが更新されました。"
+    else
+      render :edit, alert: "コメントの更新に失敗しました。"
+    end
+  end
 
+  def destroy
     if @comment.user.id == current_user.id
       if @comment.destroy
         respond_to do |format|

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,15 +1,18 @@
-<div id="comment_<%= comment.id %>" class="comment">
-  <table class="comment-table mb-4">
-    <tr>
-      <td><strong><%= comment.user.name %></strong></td>
-      <td><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></td>
-    </tr>
-    <tr>
-      <td colspan="2"><%= comment.body %></td>
-    </tr>
-  </table>
-  <% if current_user&.own?(comment) %>
-    <%= link_to "削除する", spot_comment_path(comment.spot, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-error w-full" %>
-  <% end %>
-  <div class="divider"></div>
-</div>
+<%= turbo_frame_tag comment do %>
+  <div id="comment_<%= comment.id %>" class="comment">
+    <table class="comment-table mb-4">
+      <tr>
+        <td><strong><%= comment.user.name %></strong></td>
+        <td><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+      </tr>
+      <tr>
+        <td colspan="2"><%= comment.body %></td>
+      </tr>
+    </table>
+    <% if current_user&.own?(comment) %>
+      <%= link_to "コメントを編集", edit_spot_comment_path(@spot, comment), class: "btn btn-primary w-full mb-4" %>
+      <%= link_to "コメントを削除", spot_comment_path(comment.spot, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-error w-full" %>
+    <% end %>
+    <div class="divider"></div>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,8 @@
-<%= form_with model: comment, url: spot_comments_path(spot), class: 'w-full' do |f| %>
+<%= form_with(model: comment, url: spot_comments_path(spot_id: spot.id, id: comment.id), class: 'comment_form w-full') do |f| %>
   <div class="form-control mb-4">
     <%= f.text_area :body, class: 'textarea textarea-bordered w-full', placeholder: "コメントを入力", rows: 3 %>
   </div>
-
   <div class="form-control mb-4">
-    <%= f.submit t('helpers.submit.comment_create'), class: 'btn btn-primary w-full' %>
+    <%= f.submit comment.new_record? ? "作成" : "更新", class: 'btn btn-primary w-full' %>
   </div>
 <% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,10 @@
+<%= turbo_frame_tag "comment_#{@comment.id}" do %>
+  <%= form_with(model: @comment, url: spot_comment_path(@spot, @comment), method: :put, class: 'comment_form w-full') do |f| %>
+    <div class="form-control mb-4">
+      <%= f.text_area :body, class: 'textarea textarea-bordered w-full', placeholder: "コメントを入力", rows: 3 %>
+    </div>
+    <div class="form-control mb-4">
+      <%= f.submit "更新", class: 'btn btn-primary w-full' %>
+    </div>
+  <% end %>
+<% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,7 @@ ja:
     submit:
       create: 投稿
       comment_create: コメントを投稿
+      comment_update: コメントを更新
       submit: 保存
       update: 更新
       send: 送信

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,11 @@ Rails.application.routes.draw do
   end
 
   resources :spots do
-    resources :comments, only: %i[ create destroy ]
-    resource :bookmarks, only: %i[ create destroy ]
+    resources :comments, only: %i[edit create update destroy]
+    resource :bookmarks, only: %i[create destroy]
   end
 
-  resources :bookmarks, only: %i[ index ]
+  resources :bookmarks, only: %i[index]
 
   # 利用規約
   get "terms", to: "terms#index"


### PR DESCRIPTION
# 作業内容
## ルーティング
- [x] `routes.rb`を以下のように編集
  - `Comment`のルーティングに`edit`と`update`アクションを追加
## コントローラー
- [x] `comments_controller.rb`を以下のように編集
  - コールバックメソッドに`edit`と`update`を追記
  - `edit`と`update`アクションを追記
## viewの生成
- [x] 以下を実行
  - `edit`アクションのテンプレートを生成
    ```bash
    touch app/views/comments/edit.html.erb
    ```
## viewの編集
- [x] `app/views/comments/_comment.html.erb`を編集
  - `turbo_frame_tag`で全体を囲む
- [x] `comments/edit.html.erb`を編集
  - 投稿されたコメント全体を置き換えたいので、全体をturbo_frame_tagで囲むように追記
  - コメント投稿フォームとほぼ同じようにコピペ
  - コメントの編集ボタンを追記