### PR TITLE
Feature/turbo comment post

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,7 +10,9 @@ class CommentsController < ApplicationController
     @comment.user = current_user
 
     if @comment.save
-      redirect_to @spot, notice: "コメントが投稿されました。"
+      respond_to do |format|
+        format.turbo_stream
+      end
     else
       redirect_to @spot, alert: "コメントの投稿に失敗しました。"
     end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag comment do %>
-  <div id="comment_<%= comment.id %>" class="comment">
+  <div id="comment-<%= comment.id %>" class="comment">
     <table class="comment-table mb-4">
       <tr>
-        <td><strong><%= comment.user.name %></strong></td>
+        <p><strong><%= comment.user.name %></strong></p>
         <td><%= comment.created_at.strftime("%Y/%m/%d %H:%M") %></td>
       </tr>
       <tr>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,8 +1,10 @@
-<%= form_with(model: comment, url: spot_comments_path(spot_id: spot.id, id: comment.id), class: 'comment_form w-full') do |f| %>
-  <div class="form-control mb-4">
-    <%= f.text_area :body, class: 'textarea textarea-bordered w-full', placeholder: "コメントを入力", rows: 3 %>
-  </div>
-  <div class="form-control mb-4">
-    <%= f.submit comment.new_record? ? "作成" : "更新", class: 'btn btn-primary w-full' %>
-  </div>
-<% end %>
+<div id="comment_form">
+  <%= form_with(model: comment, url: spot_comments_path(spot_id: spot.id, id: comment.id), class: 'w-full') do |f| %>
+    <div class="form-control mb-4">
+      <%= f.text_area :body, class: 'textarea textarea-bordered w-full', placeholder: "コメントを入力", rows: 3 %>
+    </div>
+    <div class="form-control mb-4">
+      <%= f.submit comment.new_record? ? "作成" : "更新", class: 'btn btn-primary w-full' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.prepend "comments" do %>
+  <%= render partial: "comments/comment", locals: { comment: @comment } %>
+<% end %>
+
+<%= turbo_stream.replace "comment_form" do %>
+  <%= render 'comments/form', spot: @spot, comment: @spot.comments.new %>
+<% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -63,7 +63,9 @@
   <div class="divider"></div>
 
   <% if @spot.comments.any? %>
-    <%= render @spot.comments %>
+    <div id="comments">
+      <%= render @spot.comments %>
+    </div>
   <% else %>
     <p class="mx-auto">コメントはまだ投稿されていません</p>
   <% end %>


### PR DESCRIPTION
# 作業内容

## commentsコントローラーの編集

- [x]  以下の内容で記述
    - `format`別に処理をわける。（respond_to制御文）
        - `turbo_stream`でのformat出力を追記する。
## `create.turbo_stream.erb`の生成・編集

- [x]  以下を実行

```bash
touch app/views/comments/create.turbo_stream.erb
```

↓

- [x]  以下の内容で記述
    - `prepend`の内容
        - コメントを`id=”comments"`の中の新しい要素として追加する。
        - コメントは、時系列で新着順に追加される。
    - `replace`の内容
        - `id=”comment_form”` の要素内を置き換える。
        - 置き換えられた`comment`には、空のインスタンス（`@spot.comments.new`）が渡される。

## `show.html.erb`の編集

- [x]  以下のように編集
    - `prepend`にて追加される要素（`id=”commnet-#{@comment.id}”`）の親要素の指定として、`id`を付与

## `_form.html.erb` の編集

- [x]  以下のように編集
    - 投稿後、コメントの中身を指定して空のインスタンスに置き換え（`replace`）たい、つまりコメント投稿前の空白の状態にしたいので、フォーム全体に`id`を付与