### PR TITLE
add:ユーザーの登録情報を編集可能に

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,53 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="w-full max-w-2xl mx-auto">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <h2 class="text-4xl font-bold text-center mb-6"><%= t('.title') %></h2>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div class="form-control mb-4">
+      <%= f.label :email, class: "label-text" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full" %>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div class="text-center text-sm text-gray-500">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+
+    <div class="form-control mb-4">
+      <%= f.label :password, "新しいパスワード", class: "label-text" %>
+      <i class="text-sm">(変更しない場合はそのままにしてください)</i>
+      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full" %>
+      <% if @minimum_password_length %>
+        <em class="text-sm text-gray-500">最低<%= @minimum_password_length %>字以上で入力してください</em>
+      <% end %>
+    </div>
+
+    <div class="form-control mb-4">
+      <%= f.label :password_confirmation, "新しいパスワードの確認",class: "label-text" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control mb-6">
+      <%= f.label :current_password, t('devise.registrations.edit.current_password'), class: "label-text" %>
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="flex justify-center">
+      <%= f.submit t('helpers.submit.update'), class: "btn btn-primary w-full" %>
+    </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <div class="text-center my-6">
+    <%= link_to t('.back'), :back, class: "w-full btn btn-neutral" %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <div class="mt-6">
+    <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: "w-full btn btn-error" %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  <div class="mt-6">
+    <%= button_to t('.cancel_account'), registration_path(resource_name), data: { confirm: "アカウントを削除しますか？", turbo_confirm: "アカウントを削除しますか？" }, method: :delete, class: "w-full btn btn-error" %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,25 +6,22 @@
     <ul class="menu menu-horizontal px-1">
       <% if user_signed_in? %>
         <li>
-          <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete } %>
+          <%= link_to t('header.create_spot'), new_spot_path %>
+        </li>
+        <li>
+          <%= link_to t('header.bookmark_index'), bookmarks_path %>
+        </li>
+        <li>
+          <%= link_to t('header.profile'), edit_user_registration_path %>
         </li>
       <% else %>
         <li>
-          <%= link_to t('header.sign_up'), new_user_registration_path %>
+          <%= link_to t('header.spot_index'), spots_path %>
         </li>
         <li>
           <%= link_to t('header.login'), new_user_session_path %>
         </li>
       <% end %>
-      <li>
-        <%= link_to t('header.create_spot'), new_spot_path %>
-      </li>
-      <li>
-        <%= link_to t('header.spot_index'), spots_path %>
-      </li>
-      <li>
-        <%= link_to t('header.bookmark_index'), bookmarks_path %>
-      </li>
     </ul>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,7 @@ ja:
         name: ユーザー名
         password: パスワード
         password_confirmation: パスワード確認
+        current_password: 現在のパスワード
       spot:
         name: スポット名
         address: 位置情報

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -56,6 +56,12 @@ ja:
         to_login_page: ログインページへ
         to_register_page: 登録ページへ
         password_forget: パスワードをお忘れの方はこちら
+      edit:
+        title: アカウント情報編集
+        submit: 更新
+        current_password: 現在のパスワード
+        cancel_account: アカウント削除
+        back: 戻る
     mailer:
       reset_password_instructions:
         subject:                    "パスワードの再設定"
@@ -65,6 +71,9 @@ ja:
         please_ignore:              "※パスワードリセットの申請に心当たりがない場合は、以降の対応は不要となります。"
         wont_change:                "※上記リンクをクリックして新しいパスワードを作成しない限り、パスワードは変更されません。"
         reset_password_within:      "※リンクの有効期限は6時間です。"
+    errors:
+      messages:
+        current_password: 現在のパスワード
   user_sessions:
     new:
       title: ログイン
@@ -93,7 +102,7 @@ ja:
     spot_index: 投稿一覧
     create_spot: 新規投稿
     bookmark_index: お気に入り
-    # profile: プロフィール
+    profile: マイページ
   footer:
     contact: お問い合わせ
     terms: 利用規約


### PR DESCRIPTION
# 作業内容

## ビュー

### `app/views/shared/_header.html.erb`**を編集**

- プロフィール詳細ページへのリンク（`devise`導入のため使用できる）を設置

### `app/views/devise/registrations/edit.html.erb` を編集

- [x] 以下のように編集
  - `devise`のユーザー情報を編集できるように最適化
  - 日本語化

## 翻訳
- [x] `ja.yml`を編集