### PR TITLE
fix:最初の投稿の際にメッセージが切り替わらないバグ

### DIFF
--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.prepend "comments" do %>
-  <%= render partial: "comments/comment", locals: { comment: @comment } %>
+<%= turbo_stream.replace "comments" do %>
+  <%= render @spot.comments %>
 <% end %>
 
 <%= turbo_stream.replace "comment_form" do %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -62,13 +62,13 @@
 
   <div class="divider"></div>
 
-  <% if @spot.comments.any? %>
-    <div id="comments">
+  <div id="comments">
+    <% if @spot.comments.any? %>
       <%= render @spot.comments %>
-    </div>
-  <% else %>
-    <p class="mx-auto">コメントはまだ投稿されていません</p>
-  <% end %>
+    <% else %>
+      <p class="text-center">コメントはまだ投稿されていません</p>
+    <% end %>
+  </div>
 </div>
 
 <div class="flex w-3/5 flex-col border-opacity-50 mx-auto mt-5">


### PR DESCRIPTION
# 作業内容
### `create.turbo_stream.erb`を編集
- [x] `prepend`で追加する処理を`replace`で投稿に紐付くコメントで置き換える処理に変更
### `show.html.erb`を編集
- [x] 制御if文自体を対象とするように変更
# 備考