### PR TITLE
Feature/change account info

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -61,8 +61,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   def update_resource(resource, params)
-    return super if params['password'].present?
+    return super if params["password"].present?
 
-    resource.update_without_password(params.except('current_password'))
+    resource.update_without_password(params.except("current_password"))
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  def update_resource(resource, params)
+    return super if params['password'].present?
+
+    resource.update_without_password(params.except('current_password'))
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,9 @@ class User < ApplicationRecord
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.name = auth.info.name
       user.email = auth.info.email
       user.password = Devise.friendly_token[0, 20]
-      user.name = auth.info.name
     end
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,32 +6,41 @@
     <%= render "devise/shared/error_messages", resource: resource %>
 
     <div class="form-control mb-4">
+      <label class="label">
+        <span class="label-text"><%= t('helpers.label.name') %></span>
+      </label>
+      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered", required: true %>
+    </div>
+
+    <div class="form-control mb-4">
       <%= f.label :email, class: "label-text" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full" %>
+      <%= f.email_field :email, autocomplete: "email", class: "input input-bordered w-full", required: true %>
     </div>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <div class="text-center text-sm text-gray-500">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <div class="form-control mb-4">
-      <%= f.label :password, "新しいパスワード", class: "label-text" %>
-      <i class="text-sm">(変更しない場合はそのままにしてください)</i>
-      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full" %>
-      <% if @minimum_password_length %>
-        <em class="text-sm text-gray-500">最低<%= @minimum_password_length %>字以上で入力してください</em>
-      <% end %>
-    </div>
+    <% if resource.uid.blank? && resource.provider.blank? %>
+      <div class="form-control mb-4">
+        <%= f.label :password, "新しいパスワード", class: "label-text" %>
+        <i class="text-sm">(変更しない場合はそのままにしてください)</i>
+        <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full" %>
+        <% if @minimum_password_length %>
+          <em class="text-sm text-gray-500">最低<%= @minimum_password_length %>字以上で入力してください</em>
+        <% end %>
+      </div>
 
-    <div class="form-control mb-4">
-      <%= f.label :password_confirmation, "新しいパスワードの確認",class: "label-text" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full" %>
-    </div>
+      <div class="form-control mb-4">
+        <%= f.label :password_confirmation, "新しいパスワードの確認",class: "label-text" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full" %>
+      </div>
 
-    <div class="form-control mb-6">
-      <%= f.label :current_password, t('devise.registrations.edit.current_password'), class: "label-text" %>
-      <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered w-full" %>
-    </div>
+      <div class="form-control mb-6">
+        <%= f.label :current_password, t('devise.registrations.edit.current_password'), class: "label-text" %>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered w-full" %>
+      </div>
+    <% end %>
 
     <div class="flex justify-center">
       <%= f.submit t('helpers.submit.update'), class: "btn btn-primary w-full" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,6 +29,8 @@ ja:
       locked: アカウントがロックされています。
       invalid: メールアドレスまたはパスワードが違います。
       timeout: セッションの有効期限が切れました。
+      user:
+        already_authenticated: "すでにログインしています。「Googleでログイン」された方は、ログアウトしてパスワードを再設定してください。"
     sessions:
       signed_in: ログインしました。
       signed_out: ログアウトしました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,8 @@ Rails.application.routes.draw do
   # 利用規約
   get "terms", to: "terms#index"
 
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks",
+    registrations: "users/registrations"
+  }
 end


### PR DESCRIPTION
# 作業内容

Googleログインで登録したユーザーはパスワードが自動生成されている。

そのため、編集ができないので、ユーザー情報の変更をpassなしで行えるようにする。

## 前提

deviseで事前に`name`カラムを許容できるパラメーターをとして、設定してあること。

## フォームに入力fieldを設置

- [x]  以下のように編集
- `app/views/devise/registrations/edit.html.erb`
    - nameフィールドを設置する。

## deviseのコントローラーを生成

### コントローラーを生成

- [x]  以下のコマンドを生成
- `devise`に関連するコントローラーを生成

```bash
bin/rails g devise:controllers users
```

【注意】`omniauth_callbacks` コントローラーを上書きするか聞かれる場合、「n」でスキップすること。

## ルーティングの設定

- [x]  以下のように編集
- `routes.rb`を編集
    - `regstrations`コントローラーのアクションを経由するように明示的に記述

## モデルの設定

- [x]  以下のように編集
- `app/models/user.rb`
    - `password`カラムを必須にしないようにコメントアウトか削除
        - `devise`では、仕様上`password`カラムは空にできないため

## registrationsコントローラーをカスタマイズ

- [x]  以下のように処理を記述
- `app/controllers/users/registrations_controller.rb`
    - update時に`password`入力を不要にする。
    
## 表示する項目を制限

### 「Googleでログイン」したユーザーには、パスワード設定が表示されないように

- [x]  以下のように編集
- `app/views/devise/registrations/edit.html.erb`
    - 「Googleでログイン」したユーザー、つまり`uid`と`provider` カラムに値が入っている場合に表示になるように。

# 備考

- https://qiita.com/00000000/items/0c7dd9b523e960dae2a9
- https://fuga-ch85.hatenablog.com/entry/2021/09/10/163606
- https://plog.kobacchi.com/rails-devise-user-profile-customize/