### PR TITLE
add:spotのcache化

### DIFF
--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -1,7 +1,9 @@
-[
-  {
-    "warning_type": "Dynamic Render Path",
-    "fingerprint": "b45aeb16f8bcc9e47633461a642d2419f65c8150797ff9550b5518303cae498f",
-    "note": "False positive: Collection rendering with render @spots is safe"
-  }
-]
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "fingerprint": "b45aeb16f8bcc9e47633461a642d2419f65c8150797ff9550b5518303cae498f",
+      "note": "False positive: Collection rendering with render @spots is safe"
+    }
+  ]
+}

--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -1,0 +1,7 @@
+[
+  {
+    "warning_type": "Dynamic Render Path",
+    "fingerprint": "b45aeb16f8bcc9e47633461a642d2419f65c8150797ff9550b5518303cae498f",
+    "note": "False positive: Collection rendering with render @spots is safe"
+  }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
+        run: bin/brakeman --no-pager --ignore-config .brakeman.ignore
 
   lint:
     runs-on: ubuntu-latest

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,18 +1,21 @@
-<div id="<%= dom_id spot %>" class="card col-span-1 bg-base-100 shadow-xl">
+<% cache(spot) do %>
+  <div id="<%= dom_id spot %>" class="card col-span-1 bg-base-100 shadow-xl">
 
-  <!-- カバー写真部分 -->
-  <figure>
-    <%= image_tag spot.image, class: "object-cover" %>
-  </figure>
+    <!-- カバー写真部分 -->
+    <figure>
+      <%= image_tag spot.image.variant(resize_to_limit: [1200, 800]).processed, class: "object-cover" %>
+    </figure>
 
-  <!-- 本文部分 -->
-  <div class="card-body">
-    <h2 class="card-title"><%= spot.name %></h2>
-    <p><%= spot.prefecture.name %><%= spot.address %></p>
-    <div class="card-actions justify-end">
-      <%= render 'spots/bookmark_buttons', { spot: spot } %>
-      <%= link_to "詳細", spot, class: "btn btn-primary" %>
+    <!-- 本文部分 -->
+    <div class="card-body">
+      <h2 class="card-title"><%= spot.name %></h2>
+      <p><%= spot.prefecture.name %><%= spot.address %></p>
+      <div class="card-actions justify-end">
+        <%= render 'spots/bookmark_buttons', { spot: spot } %>
+        <%= link_to "詳細", spot, class: "btn btn-primary" %>
+      </div>
     </div>
+
   </div>
 
-</div>
+<% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -4,9 +4,7 @@
 
 <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
   <% if @spots.any? %>
-    <% @spots.each do |spot| %>
-      <%= render spot %>
-    <% end %>
+    <%= render @spots %>
   <% else %>
     <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
   <% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -4,66 +4,68 @@
   <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
 <% end %>
 -->
-<h1 class="font-bold text-4xl p-3"><%= @spot.name%></h1>
-<div class="grid sm:grid-cols-3">
-  <figure class="sm:col-span-2 mb-3">
-    <%= image_tag @spot.image, class: "rounded" %>
-  </figure>
+<% cache(@spot) do %>
+  <h1 class="font-bold text-4xl p-3"><%= @spot.name%></h1>
+  <div class="grid sm:grid-cols-3">
+    <figure class="sm:col-span-2 mb-3">
+      <%= image_tag @spot.image, class: "rounded" %>
+    </figure>
 
-  <div class="bg-neutral sm:g sm:mx-4 w-full rounded">
-    <h1 class="bg-info text-info-content p-4 text-xl rounded">基本情報</h1>
+    <div class="bg-neutral sm:g sm:mx-4 w-full rounded">
+      <h1 class="bg-info text-info-content p-4 text-xl rounded">基本情報</h1>
 
-    <div class="py-5 mx-5">
-      <div class="divider divider-info text-xl">位置情報</div>
-      <div class="text-lg">
-        <%= @spot.prefecture.name %><%= @spot.address %>
-      </div>
-    </div>
-
-    <div class="py-5 mx-5">
-      <div class="divider divider-info text-xl">説明</div>
-      <% if @spot.body.present? %>
-        <div class="overflow-x-auto break-words max-h-48">
-          <%= simple_format(@spot.body) %>
+      <div class="py-5 mx-5">
+        <div class="divider divider-info text-xl">位置情報</div>
+        <div class="text-lg">
+          <%= @spot.prefecture.name %><%= @spot.address %>
         </div>
-      <% else %>
-        <p class="text-base-content">情報がありません</p>
-      <% end %>
-    </div>
+      </div>
 
-    <div class="py-5 mx-5">
-      <div class="divider divider-info text-xl">公式サイト</div>
-      <div class="text-lg text-primary">
-        <% if @spot.url.present? %>
-          <div class="overflow-x-auto break-words max-h-12">
-            <%= link_to nil, Spot.find(params[:id]).url.to_s, target: "_blank" %>
+      <div class="py-5 mx-5">
+        <div class="divider divider-info text-xl">説明</div>
+        <% if @spot.body.present? %>
+          <div class="overflow-x-auto break-words max-h-48">
+            <%= simple_format(@spot.body) %>
           </div>
         <% else %>
           <p class="text-base-content">情報がありません</p>
         <% end %>
       </div>
-    </div>
 
-    <div class="py-5 mx-5">
-      <div class="divider divider-info text-xl">投稿者</div>
-      <div class="text-lg">
-        <%= @spot.user.name %>
+      <div class="py-5 mx-5">
+        <div class="divider divider-info text-xl">公式サイト</div>
+        <div class="text-lg text-primary">
+          <% if @spot.url.present? %>
+            <div class="overflow-x-auto break-words max-h-12">
+              <%= link_to nil, Spot.find(params[:id]).url.to_s, target: "_blank" %>
+            </div>
+          <% else %>
+            <p class="text-base-content">情報がありません</p>
+          <% end %>
+        </div>
       </div>
-    </div>
 
-    <div class="flex justify-center mx-5 mb-2 items-center">
-      <%= link_to "https://x.com/intent/tweet?text=#{CGI.escape("【#{@spot.name}】をシェアしました！\n\nスポット名：#{@spot.name}\n位置情報：#{@spot.prefecture.name + @spot.address}\n投稿者：#{@spot.user.name}\n\n#{request.url}\n#NighTrip #夜景")}", target: '_blank', class: "btn btn-default flex items-center gap-2" do %>
-        <svg class="h-6 w-6 text-slate-500" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-          <path d="M4 4l11.733 16h4.267l-11.733 -16z" />
-          <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
-        </svg>
-        <span>でシェア</span>
-      <% end %>
-    </div>
+      <div class="py-5 mx-5">
+        <div class="divider divider-info text-xl">投稿者</div>
+        <div class="text-lg">
+          <%= @spot.user.name %>
+        </div>
+      </div>
 
+      <div class="flex justify-center mx-5 mb-2 items-center">
+        <%= link_to "https://x.com/intent/tweet?text=#{CGI.escape("【#{@spot.name}】をシェアしました！\n\nスポット名：#{@spot.name}\n位置情報：#{@spot.prefecture.name + @spot.address}\n投稿者：#{@spot.user.name}\n\n#{request.url}\n#NighTrip #夜景")}", target: '_blank', class: "btn btn-default flex items-center gap-2" do %>
+          <svg class="h-6 w-6 text-slate-500" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+            <path d="M4 4l11.733 16h4.267l-11.733 -16z" />
+            <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
+          </svg>
+          <span>でシェア</span>
+        <% end %>
+      </div>
+
+    </div>
   </div>
-</div>
+<% end %>
 
 <%# コメント部分 %>
 <div class="flex w-3/5 flex-col mx-auto my-8">


### PR DESCRIPTION
# 作業内容
## キャッシュ化
- [x] 以下のファイルでキャッシュ化
  - `app/views/spots/_spot.html.erb`
    - `spot`の投稿された情報は、更新頻度が高くないことからキャッシュ化することが有効と判断。
    ```html
    <% cache(spot) do %>
      <div id="<%= dom_id spot %>" class="card col-span-1 bg-base-100 shadow-xl">
    .. 省略 ..
    <% end %>
    ```
  - `app/views/spots/index.html.erb`
    - `@spots`をそのまま`render`メソッドに渡すことで、コレクションキャッシュとしてフラグメントキャッシュが有効になり、各`spot`のカードが毎回読み込まれない。また、アクセス頻度も高いことから、キャッシュ化の恩恵を受けやすい。
    ```html
    <% @spots.each do |spot| %>
      <% cache(spot) do %>
        <%= render spot %>
      <% end %>
    <% end %>
    ```
    ↓
    ```html
      <% if @spots.any? %>
        <%= render @spots %>
      <% else %>
      ```
  - `app/views/spots/show.html.erb`
    - `spot`の投稿された情報は、更新頻度が高くないことからキャッシュ化することが有効と判断。
# 備考
- [[Rails]キャッシュについて](https://zenn.dev/redheadchloe/articles/04fd98e2b50161)
- [コレクションキャッシュ](https://railsguides.jp/v7.1/caching_with_rails.html#%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5)