### PR TITLE
Feature/loading animation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.0.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -465,7 +465,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap
-  brakeman
+  brakeman (~> 7.0.2)
   capybara
   cssbundling-rails
   debug

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,10 +27,10 @@ module ApplicationHelper
 
   # == Buttons ==
   def back_button(label = t("helpers.label.back"))
-    link_to label, :back, class: "btn btn-neutral w-full"
+    link_to label, :back, class: "btn btn-neutral w-full", data: { action: "click->loading#show" }
   end
 
   def spots_index_button(label = t("helpers.label.spots_index"))
-    link_to label, spots_path, class: "btn btn-primary w-full"
+    link_to label, spots_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" }
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Controller for showing loading spinner during form submission
+export default class extends Controller {
+  static targets = ["infinity"]
+
+  connect() {
+    this.hide()
+  }
+
+  show() {
+    this.infinityTarget.classList.remove("hidden")
+  }
+
+  hide() {
+    this.infinityTarget.classList.add("hidden")
+  }
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -61,7 +61,7 @@
 
       <!-- 更新ボタン -->
       <div>
-        <%= f.submit t('helpers.submit.update'), class: "btn btn-primary w-full" %>
+        <%= f.submit t('helpers.submit.update'), class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
       </div>
     </div>
   <% end %>
@@ -71,9 +71,9 @@
       <%= back_button %>
     </div>
 
-    <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: "w-full btn btn-error" %>
+    <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete, action: "click->loading#show" }, class: "w-full btn btn-error" %>
 
-    <%= button_to t('.cancel_account'), registration_path(resource_name), data: { confirm: "アカウントを削除しますか？", turbo_confirm: "アカウントを削除しますか？" }, method: :delete, class: "w-full btn btn-error" %>
+    <%= button_to t('.cancel_account'), registration_path(resource_name), data: { confirm: "アカウントを削除しますか？", turbo_confirm: "アカウントを削除しますか？", action: "click->loading#show" }, method: :delete, class: "w-full btn btn-error" %>
   </div>
 
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -53,7 +53,7 @@
             </div>
             <div class="divider">OR</div>
             <div class="card bg-base-300 rounded-box grid place-items-center">
-              <%= link_to t('.to_login_page'), new_user_session_path, class: "btn btn-primary w-full" %>
+              <%= link_to t('.to_login_page'), new_user_session_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
             </div>
           </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -39,19 +39,19 @@
             <div class="card rounded-box grid place-items-center">
               <!-- ログインボタン -->
               <div class="form-control w-full">
-                <%= f.submit t('helpers.submit.login'), class: "btn btn-primary" %>
+                <%= f.submit t('helpers.submit.login'), class: "btn btn-primary", data: { action: "click->loading#show" } %>
               </div>
               <div class="form-control w-full mt-5">
-                <%= link_to "Googleでログイン / 新規登録", user_google_oauth2_omniauth_authorize_path, class: "btn btn-primary" %>
+                <%= link_to "Googleでログイン / 新規登録", user_google_oauth2_omniauth_authorize_path, class: "btn btn-primary", data: { action: "click->loading#show" } %>
               </div>
             </div>
             <div class="card bg-base-300 rounded-box grid place-items-center mt-5">
-              <%= link_to t('.to_registration'), new_user_registration_path, class: "btn btn-primary w-full" %>
+              <%= link_to t('.to_registration'), new_user_registration_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
             </div>
           </div>
 
           <div class="card bg-base-300 rounded-box grid place-items-center mt-4">
-            <%= link_to t('.forget_password'), new_user_password_path, class: "btn btn-primary w-full" %>
+            <%= link_to t('.forget_password'), new_user_password_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
           </div>
 
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,47 +31,56 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <%= render 'shared/header' %>
-
-    <!-- Notification -->
-    <% if notice %>
-      <div id="notice-alert" role="alert" class="alert alert-info transition-opacity opacity-100">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          class="h-6 w-6 shrink-0 stroke-current">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-        </svg>
-        <span><%= notice %></span>
+    <div data-controller="loading">
+      <div data-loading-target="infinity" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
+        <div class="h-[150px] w-[150px] flex items-center justify-center">
+          <span class="loading loading-infinity text-default w-full h-full"></span>
+        </div>
       </div>
-    <% end %>
-    <% if alert %>
-      <div id="alert-alert" role="alert" class="alert alert-error transition-opacity opacity-100">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-6 w-6 shrink-0 stroke-current"
-          fill="none"
-          viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span><%= alert %></span>
-      </div>
-    <% end %>
 
-    <div class="w-5/6 mx-auto max-w-screen-xl flex-grow">
-      <%= yield %>
+      <%= render 'shared/header' %>
+
+      <!-- Notification -->
+      <% if notice %>
+        <div id="notice-alert" role="alert" class="alert alert-info transition-opacity opacity-100">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            class="h-6 w-6 shrink-0 stroke-current">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <span><%= notice %></span>
+        </div>
+      <% end %>
+      <% if alert %>
+        <div id="alert-alert" role="alert" class="alert alert-error transition-opacity opacity-100">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6 shrink-0 stroke-current"
+            fill="none"
+            viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span><%= alert %></span>
+        </div>
+      <% end %>
+
+      <div class="w-5/6 mx-auto max-w-screen-xl flex-grow">
+        <%= yield %>
+      </div>
+
+      <%= render 'shared/footer' %>
+
     </div>
-
-    <%= render 'shared/footer' %>
 
     <script>
       document.addEventListener("turbo:load", function() {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,7 +5,8 @@
                 target: "_blank",
                 rel: "noopener noreferrer" %>
     <%= link_to t('footer.terms'), terms_path,
-                class: "link link-hover" %>
+                class: "link link-hover",
+                data: { action: "click->loading#show" } %>
     <%= link_to t('footer.privacy_policy'), "https://kiyac.app/privacypolicy/qO1wEtf0KvWQzyLaRJGK",
                 class: "link link-hover",
                 target: "_blank",

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <% style_color = "text-neurral-100" %>
 <div class="navbar bg-base-100 mb-3">
   <div class="flex-1">
-    <%= link_to root_path, class: 'btn btn-ghost text-xl' do %>
+    <%= link_to root_path, class: 'btn btn-ghost text-xl', data: { action: "click->loading#show" } do %>
       <%= image_tag "apple-touch-icon.png", alt: "NighTrip", class: "h-10 w-auto align-middle" %>
       <span>NighTrip</span>
     <% end %>
@@ -10,7 +10,7 @@
     <ul class="menu menu-horizontal px-1">
       <% if user_signed_in? %>
         <li>
-          <%= link_to new_spot_path, class: style_color do %>
+          <%= link_to new_spot_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="10" />
               <line x1="12" y1="8" x2="12" y2="16" />
@@ -20,7 +20,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to ranking_spots_path, class: style_color do %>
+          <%= link_to ranking_spots_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round">
               <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
               <polyline points="17 6 23 6 23 12" />
@@ -29,8 +29,7 @@
           <% end %>
         </li>
         <li>
-        <li>
-          <%= link_to bookmarks_path, class: style_color do %>
+          <%= link_to bookmarks_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round">
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
@@ -38,7 +37,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to edit_user_registration_path, class: style_color do %>
+          <%= link_to edit_user_registration_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z"/>
               <circle cx="12" cy="7" r="4" />
@@ -49,7 +48,7 @@
         </li>
       <% else %>
         <li>
-          <%= link_to ranking_spots_path, class: style_color do %>
+          <%= link_to ranking_spots_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round">
               <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
               <polyline points="17 6 23 6 23 12" />
@@ -58,7 +57,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to spots_path, class: style_color do %>
+          <%= link_to spots_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
             </svg>
@@ -66,7 +65,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to new_user_session_path, class: style_color do %>
+          <%= link_to new_user_session_path, class: style_color, data: { action: "click->loading#show" } do %>
             <svg class="h-6 w-6"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z"/>
               <path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" />

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,7 +1,0 @@
-<div
-  data-controller="loading"
-  data-loading-target="spinner"
-  class="fixed inset-0 z-50 bg-black bg-opacity-40 hidden flex items-center justify-center"
->
-  <span class="loading loading-spinner loading-lg text-primary"></span>
-</div>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,0 +1,7 @@
+<div
+  data-controller="loading"
+  data-loading-target="spinner"
+  class="fixed inset-0 z-50 bg-black bg-opacity-40 hidden flex items-center justify-center"
+>
+  <span class="loading loading-spinner loading-lg text-primary"></span>
+</div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: spot, class: "contents") do |form| %>
+<%= form_with(model: spot, class: "contents", turbo: false) do |form| %>
   <% if spot.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-md my-3">
       <h2><%= spot.errors.count %> 件のエラーにより、スポットは保存できませんでした</h2>
@@ -71,6 +71,6 @@
   </div>
 
   <div class="flex w-3/5 flex-col border-opacity-50 mx-auto mt-5">
-    <%= form.submit class: "btn btn-primary w-full" %>
+    <%= form.submit class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
   </div>
 <% end %>

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="col-span-5">
-      <%= f.submit "検索", class: "btn btn-primary w-full" %>
+      <%= f.submit "検索", class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
     </div>
 
     <div class="col-span-1">

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -10,14 +10,14 @@
     <h2 class="card-title"><%= spot.name %></h2>
     <p><%= spot.prefecture.name %><%= spot.address %></p>
     <div class="card-actions justify-end">
-      <%= link_to spot_path(spot, anchor: "comment_form"), class: "btn btn-secondary" do %>
+      <%= link_to spot_path(spot, anchor: "comment_form"), class: "btn btn-secondary", data: { action: "click->loading#show" } do %>
         <svg class="h-6 w-6 text-slate-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
         </svg>
         <%= spot.comments.count %>
       <% end %>
       <%= render 'spots/bookmark_buttons', { spot: spot } %>
-      <%= link_to "詳細", spot, class: "btn btn-primary" %>
+      <%= link_to "詳細", spot, class: "btn btn-primary", data: { action: "click->loading#show" } %>
     </div>
   </div>
 

--- a/app/views/spots/ranking.html.erb
+++ b/app/views/spots/ranking.html.erb
@@ -14,10 +14,10 @@
     <% @top_5_bookmarked_spots.each_with_index do |spot, index| %>
       <tr>
         <td class="border border-gray-800"><%= index + 1 %> 位</td>
-        <td class="border border-gray-800"><%= link_to spot.name, spot_path(spot) %></td>
+        <td class="border border-gray-800"><%= link_to spot.name, spot_path(spot), data: { action: "click->loading#show" } %></td>
         <td class="border border-gray-800">
           <%= link_to spot_path(spot) do %>
-            <%= image_tag spot.image, class: "w-40 h-20 object-cover rounded" %>
+            <%= image_tag spot.image, class: "w-40 h-20 object-cover rounded", data: { action: "click->loading#show" } %>
           <% end %>
         </td>
         <td class="border border-gray-800"><%= spot.bookmarks.count %></td>

--- a/app/views/top/home.html.erb
+++ b/app/views/top/home.html.erb
@@ -6,7 +6,7 @@
   <div class="hero-content text-neutral-content text-center">
     <div class="max-w-3xl">
       <h1 class="mb-5 text-5xl font-bold">心に残る夜景を、ここで見つけよう</h1>
-      <%= link_to t('top.home.search_spots'), spots_path, class: "btn btn-primary" %>
+      <%= link_to t('top.home.search_spots'), spots_path, class: "btn btn-primary", data: { action: "click->loading#show" } %>
     </div>
   </div>
 </div>
@@ -53,12 +53,12 @@
   <div class="flex w-3/5 flex-col border-opacity-50">
     <!-- button for user registration -->
     <div class="card bg-base-300 rounded-box grid place-items-center">
-      <%= link_to t('top.home.to_registration_page'), new_user_registration_path, class: "btn btn-primary w-full" %>
+      <%= link_to t('top.home.to_registration_page'), new_user_registration_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
     </div>
     <div class="divider">OR</div>
     <!-- button for login -->
     <div class="card bg-base-300 rounded-box grid place-items-center">
-      <%= link_to t('top.home.to_login_page'), new_user_session_path, class: "btn btn-primary w-full" %>
+      <%= link_to t('top.home.to_login_page'), new_user_session_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" } %>
     </div>
   </div>
 </div>

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -728,6 +728,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1743724091
+    "timestamp": 1743790962
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-04T08:48:11+09:00">2025-04-04T08:48:11+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-05T03:22:42+09:00">2025-04-05T03:22:42+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -6202,7 +6202,7 @@
 
             
 
-            <code class="ruby">    link_to label, :back, class: &quot;btn btn-neutral w-full&quot;</code>
+            <code class="ruby">    link_to label, :back, class: &quot;btn btn-neutral w-full&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
           </li>
         </div>
       
@@ -6246,7 +6246,7 @@
 
             
 
-            <code class="ruby">    link_to label, spots_path, class: &quot;btn btn-primary w-full&quot;</code>
+            <code class="ruby">    link_to label, spots_path, class: &quot;btn btn-primary w-full&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
           </li>
         </div>
       


### PR DESCRIPTION
# 作業内容
## ターミナル

- [x]  以下を実行

```bash
bin/rails stimulus:install
```

↓

- [x]  以下を実行
- `app/javascript/controllers/loading_controller.js`を生成

```bash
bin/rails g stimulus loading
```

以下が行われる。

- `app/javascript/controllers/index.js`への自動追記
- `app/javascript/controllers/loading_controller.js`の作成

↓

## ビュー

- [x]  `app/views/layouts/application.html.erb` を編集
    - ローディングアニメーションが全てのページでレンダリングされるように

## JS

- [x]  `app/javascript/controllers/loading_controller.js`を編集
- `static targets`
    - 以降の記述で、`XXXTarget`を使用可能にする記述
    - https://stimulus.hotwired.dev/handbook/building-something-real#what%E2%80%99s-with-that-static-targets-line%3F ←にて詳細説明🐜。
- `connect`
    - ページ読み込み（command + ←など）の際に、アニメーションが無限再生されないように
- `show`
    - ローディングアニメーションのスピナーが表示されるように
- `hide`
    - ローディングアニメーションのスピナーが非表示にされるように

## ビュー

### 各ビューへ付与

- 各ビューファイルで要素に「`data: { action: "click->loading#show”`」を付与
- 付与したファイルは以下
  - `app/views/top/home.html.erb`
  - `app/views/shared/_header.html.erb`
  - `app/views/shared/_footer.html.erb`
  - `app/views/devise/registrations/new.html.erb`
  - `app/views/devise/registrations/edit.html.erb`
  - `app/views/devise/sessions/new.html.erb`
  - `app/views/spots/_form.html.erb`
  - `app/views/spots/_spot.html.erb`
  - `app/views/spots/ranking.html.erb`
  - `app/views/spots/_search_form.html.erb`
  - `app/helpers/application_helper.rb`

# 備考
- https://github.com/hotwired/stimulus-rails/
- https://stimulus.hotwired.dev/
- https://stimulus.hotwired.dev/handbook/installing
- https://blog.to-ko-s.com/stimlus-introduce/
- https://qiita.com/eichann/items/d175985fc8eaa597819b
- https://zenn.dev/redheadchloe/articles/cf275fe0fafe4f
- https://dev.to/bhumi/stimulus-rails-7-tutorial-5a6a