### PR TITLE
fix:コメントが無い場合の文言が正しく表示されるように

### DIFF
--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,1 +1,7 @@
 <%= turbo_stream.remove @comment %>
+
+<% if @spot.comments.empty? %>
+  <%= turbo_stream.prepend "comments" do %>
+    <p id="no_comments" class="text-center">今がチャンス！最初のコメントを投稿してみましょう</p>
+  <% end %>
+<% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -87,7 +87,7 @@
     <% if @spot.comments.any? %>
       <%= render @spot.comments.order(created_at: :desc) %>
     <% else %>
-      <p id="no_comments" class="text-center">コメントはまだ投稿されていません</p>
+      <p id="no_comments" class="text-center">今がチャンス！最初のコメントを投稿してみましょう</p>
     <% end %>
   </div>
 


### PR DESCRIPTION
# 作業内容
- [x] `destroy.turbo_stream.erb`を編集
  - コメントが非同期で無くなった場合、「今がチャンス！最初のコメントを投稿してみましょう」が表示されるように
- [x] `app/views/spots/show.html.erb`を編集
  - ページが表示されコメントがない場合、「今がチャンス！最初のコメントを投稿してみましょう」が表示されるように