### PR TITLE
add:Google Mapの表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,10 @@ gem "omniauth"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+# GoogleMaps
+# 緯度軽度変換
+gem "geocoder"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.3)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -155,6 +156,9 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -473,6 +477,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  geocoder
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -79,5 +79,4 @@ class Spot < ApplicationRecord
   def url_present?
     url.present?
   end
-
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -7,11 +7,15 @@ class Spot < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
 
-  # == ActiveStorage ==
+  # == Active Storage ==
   has_one_attached :image
 
-  # == VirtualAttributes ==
+  # == Virtual Attributes ==
   attr_accessor :tag_names
+
+  # == Geocoder ==
+  geocoded_by :full_address
+  after_validation :geocode, if: :will_save_change_to_address?
 
   # == Validations ==
   validates :name, presence: true, length: { maximum: 30 }
@@ -33,11 +37,7 @@ class Spot < ApplicationRecord
       .limit(5)
   }
 
-  # == Instance Methods ==
-  def bookmarked_by?(user)
-    bookmarks.exists?(user_id: user.id)
-  end
-
+  # == Class Methods ==
   # == Ransack ==
   def self.ransackable_attributes(auth_object = nil)
     [ "address", "body", "name", "prefecture_id", "created_at" ]
@@ -47,6 +47,11 @@ class Spot < ApplicationRecord
     %w[ prefecture tags ]
   end
 
+  # == Instance Methods ==
+  def bookmarked_by?(user)
+    bookmarks.exists?(user_id: user.id)
+  end
+
   def assign_tags
     return unless tag_names
 
@@ -54,7 +59,13 @@ class Spot < ApplicationRecord
     self.tags = names.map { |name| Tag.find_or_create_by(name: name) }
   end
 
+  def full_address
+    "#{prefecture.name}#{address}"
+  end
+
   private
+
+  # == Instance Methods ==
 
   def validate_tag_limit
     return unless tag_names
@@ -69,13 +80,4 @@ class Spot < ApplicationRecord
     url.present?
   end
 
-  # def assign_tags
-  #   return unless tag_names
-
-  #   names = tag_names.split(/[[:space:]]|　+/).map(&:strip).reject(&:blank?).uniq
-  #   if names.size > 3
-  #     return
-  #   end
-  #   self.tags = names.map { |name| Tag.find_or_create_by(name: name) }
-  # end
 end

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -28,14 +28,6 @@
       </thead>
       <tbody>
         <tr>
-          <%# 位置情報部 %>
-          <td class="font-bold border border-gray-800">位置情報</td>
-          <td class="border border-gray-800 break-words max-h-32 overflow-y-auto">
-            <% full_address = "#{@spot.prefecture.name}#{@spot.address}" %>
-            <%= link_to full_address, "https://www.google.com/maps?q=#{CGI.escape(full_address)}", target: "_blank", rel: "noopener", class: "text-info break-words max-h-32 overflow-y-auto" %>
-          </td>
-        </tr>
-        <tr>
           <%# 説明部%>
           <td class="font-bold border border-gray-800">説明</td>
           <td class="border border-gray-800">
@@ -97,6 +89,17 @@
 
 </div>
 
+<%# Google Maps部 %>
+<div class="my-5 text-wrap">
+  <% if @spot.latitude.present? && @spot.longitude.present? %>
+    <h3 class="text-xl font-bold mb-1">位置情報</h3>
+    <%= link_to @spot.full_address, "https://www.google.com/maps?q=#{CGI.escape(@spot.full_address)}", target: "_blank", rel: "noopener", class: "text-info text-lg underline" %>
+    <div id="map" style="height: 400px;" class="mt-1 rounded"></div>
+  <% else %>
+    <p class="text-center">位置情報が取得できませんでした</p>
+  <% end %>
+</div>
+
 <%# コメント部分 %>
 <div class="flex w-3/5 flex-col mx-auto">
   <%= render 'comments/form', comment: @comment, spot: @spot %>
@@ -124,3 +127,24 @@
   <%= back_button %>
   <%= spots_index_button %>
 </div>
+
+<!-- JavaScript部 -->
+<script async
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
+</script>
+
+<script>
+  function initMap() {
+    const spotLocation = { lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %> };
+    const map = new google.maps.Map(document.getElementById("map"), {
+      zoom: 14,
+      center: spotLocation,
+    });
+
+    new google.maps.Marker({
+      position: spotLocation,
+      map: map,
+      title: "<%= @spot.name %>"
+    });
+  }
+</script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV['GOOGLE_MAP_API_KEY'],               # API key for geocoding service
+  api_key: ENV["GOOGLE_MAP_API_KEY"],               # API key for geocoding service
 
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
@@ -28,6 +28,6 @@ Geocoder.configure(
   cache: Rails.cache,
   cache_options: {
     expiration: 2.days,
-    prefix: 'geocoder:'
+    prefix: "geocoder:"
   }
 )

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,33 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAP_API_KEY'],               # API key for geocoding service
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+
+  timeout: 5,                   # タイムアウト時間（秒）
+  cache: Rails.cache,
+  cache_options: {
+    expiration: 2.days,
+    prefix: 'geocoder:'
+  }
+)

--- a/db/migrate/20250406111049_add_location_to_spots.rb
+++ b/db/migrate/20250406111049_add_location_to_spots.rb
@@ -1,0 +1,6 @@
+class AddLocationToSpots < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spots, :latitude, :float
+    add_column :spots, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_06_021327) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_06_111049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_06_021327) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_spots_on_user_id"
   end
 


### PR DESCRIPTION
# 作業内容

## Google Maps の API Key を取得

- [x]  APIキーを`.env`に記載

## 住所・緯度・経度カラムを追加

### ターミナル

`prefecture`カラムと`address`カラムが、すでに実装されておりそれらのカラムを取得できるため、緯度(latitude)、経度(longitude)カラムをそれぞれテーブル（今回はSpotsテーブル）に追加

- [x]  以下のコマンドを実行

```bash
bin/rails generate migration AddLocationToSpots latitude:float longitude:float
```

↓

- [x]  以下のコマンドを実行

```bash
bin/rails db:migrate
```

## `geocoder` gemを導入

入された住所から緯度と経度を取得するためのgem、`geocoder`を追加する。

### ターミナル

- [x]  以下のように編集
- `Gemfile`

```ruby
gem "geocoder"
```

↓

- [x]  以下のコマンドを実行

```ruby
bundle install
```

↓
モデル（ここではSpot）に以下のように記述 
- geocoded_by
- after_validation :geocode
- full_addressインスタンスメソッド
↓

以上により、Spotモデルで住所登録時と変更時に`geocoder`が緯度・経度のデータを登録・更新してくれる。

## ビューにGoogle Mapsを表示させる

### ビュー

- `app/views/spots/show.html.erb`
  - 地図の表示
  - APIリクエストと地図表示のためJSの記述
 
## 詳細な位置情報(緯度・経度)を取得できるように

### ターミナル

- [x]  以下のコマンドを実行

```html
bin/rails g geocoder:config
```

- `config/initializers/geocoder.rb`が作成される。

↓

以下のパラメーターを有効化

- `lookup` ：google
- `use_https`：false
- `api_key`：ENV['GOOGLE_MAP_API_KEY']

## キャッシュの設定

- **`config/environments/production.rb`**

```ruby
config.cache_store = :memory_store, { size: 64.megabytes }
```

↓

## RenderにてAPIを設定