### PR TITLE
add:metaタグを最適化

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: "NighTrip",
-      title: "夜景スポット共有アプリ",
+      title: "",
       reverse: true,
       separator: "|",
       charset: "utf-8",

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "お気に入り一覧" %>
+
 <h1 class="text-center text-2xl font-bold">お気に入り登録しているスポット</h1>
 
 <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "パスワード再設定" %>
+
 <div class="hero min-h-screen">
   <div class="hero-content flex-col w-full">
     <div class="text-center lg:text-left mb-5">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "アカウント情報編集" %>
+
 <h1 class="text-center text-2xl font-bold"><%= t('.title') %></h1>
 
 <div class="w-full max-w-2xl mx-auto my-8">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "新規会員登録" %>
+
 <div class="hero min-h-screen">
   <div class="hero-content flex-col w-full">
     <div class="text-center lg:text-left mb-5">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "ログイン" %>
+
 <div class="hero min-h-screen">
   <div class="hero-content flex-col w-full">
     <div class="text-center lg:text-left mb-5">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) %></title>
+    <title><%= yield(:title) || "NighTrip" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "New spot" %>
+<% content_for :title, "新規投稿" %>
 
 <div class="md:w-2/3 w-full mx-auto">
 

--- a/app/views/spots/ranking.html.erb
+++ b/app/views/spots/ranking.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "ランキング" %>
+
 <h1 class="text-center text-2xl font-bold">TOP5お気に入り数スポット</h1>
 
 <table class="table border border-gray-800 my-8">


### PR DESCRIPTION
# 作業内容
## 各ページのmetaタグを最適化
- [x] `app/views/layouts/application.html.erb`
  - デフォルトでページタイトルが、ない場合アプリタイトルが表示されるように設定
- [x] `app/helpers/application_helper.rb`
  - タイトルが表示されないように
- [x] 以下のページにタイトルを設定
  - `app/views/spots/new.html.erb`
  - `app/views/spots/ranking.html.erb`
  - `app/views/bookmarks/index.html.erb`
  - `app/views/devise/registrations/edit.html.erb`
  - `app/views/devise/registrations/new.html.erb`
  - `app/views/devise/sessions/new.html.erb`
  - `app/views/devise/passwords/new.html.erb`