### PR TITLE
fix:投稿フォームを最適化

### DIFF
--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: spot, class: "contents", turbo: false) do |f| %>
+<%= form_with(model: spot, class: "contents") do |f| %>
   <%# エラー部 %>
   <% if spot.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-md my-3">
@@ -17,15 +17,15 @@
 
     <%# スポット名 %>
     <div class="form-group">
-      <%= f.label :name, class: "form-label" do %>
+      <%= f.label :name, class: "form-label", for: :spot_name do %>
         スポット名（最大30文字） <span class="bg-red-700 text-xs ml-1 text-white rounded p-1">必須</span>
       <% end %>
-      <%= f.text_field :name, required: true, placeholder: "例: 東京タワー", class: "w-full input input-bordered" %>
+      <%= f.text_field :name, required: true, placeholder: "例：東京タワー", class: "w-full input input-bordered" %>
     </div>
 
     <%# 住所（都道府県） %>
     <div class="form-group">
-      <%= f.label :prefecture_id, class: "form-label" do %>
+      <%= f.label :prefecture_id, class: "form-label", for: :spot_prefecture do %>
         都道府県 <span class="bg-red-700 text-xs ml-1 text-white rounded p-1">必須</span>
       <% end %>
       <%= f.select :prefecture_id, Prefecture.all.collect { |p| [p.name, p.id] }, { include_blank: "選択してください" }, { required: true, class: "w-full input input-bordered" } %>
@@ -33,37 +33,27 @@
 
     <%# 住所（詳細） %>
     <div class="form-group">
-      <%= f.label :address, class: "form-label" do %>
+      <%= f.label :address, class: "form-label", for: :spot_address do %>
         市区町村番地（最大60文字） <span class="bg-red-700 text-xs ml-1 text-white rounded p-1">必須</span>
       <% end %>
-      <%= f.text_field :address, required: true, placeholder: "例: 港区芝公園4-2-8", class: "w-full input input-bordered" %>
+      <%= f.text_field :address, required: true, placeholder: "例：港区芝公園4-2-8", class: "w-full input input-bordered" %>
     </div>
 
     <%# URL %>
     <div class="form-group">
-      <%= f.label :url, "サイトURL（最大255文字）", class: "form-label" %>
-      <label class="input input-bordered flex items-center gap-2">
-        <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2.5" fill="none" stroke="currentColor">
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-          </g>
-        </svg>
-        <%= f.url_field :url,
-          maxlength: 255,
-          placeholder: "https://",
-          pattern: "^(https?://)?([a-zA-Z0-9]([a-zA-Z0-9\\-].*[a-zA-Z0-9])?\\.)+[a-zA-Z].*$",
-          title: "有効なURLでなければいけません",
-          class: "grow" %>
-      </label>
-      <p class="validator-hint text-sm text-gray-500 mt-1">有効なURLを入力してください（例: https://example.com）</p>
+      <%= f.label :url, "サイトURL（最大255文字）", class: "form-label", for: :spot_url %>
+      <%= f.url_field :url,
+        maxlength: 255,
+        placeholder: "例: https://example.com",
+        title: "有効なURLでなければいけません",
+        class: "input input-bordered w-full" %>
     </div>
 
     <%# タグ %>
     <div class="form-group">
-      <%= f.label :tag_names, "タグ（最大3つ）", class: "form-label" %>
+      <%= f.label :tag_names, "タグ（最大3つ）", class: "form-label", for: :spot_tags %>
       <%= f.text_field :tag_names, value: spot.tags.map(&:name).join(' '
-), placeholder: "タワー 展望台 都会", class: "input input-bordered w-full", data: { max_tags: 3 } %>
+), placeholder: "例：タワー 展望台 都会", class: "input input-bordered w-full" %>
 
       <% if f.object.errors[:tag_names].present? %>
         <div class="text-red-500 text-sm mt-1">
@@ -74,16 +64,16 @@
 
     <%# 説明 %>
     <div class="form-group">
-      <%= f.label :body, "説明", class: "form-label" %>
-      <%= f.text_area :body, rows: 2, placeholder: "スポットの特徴や魅力を記入してください", class: "textarea textarea-bordered w-full" %>
+      <%= f.label :body, "説明", class: "form-label", for: :spot_body %>
+      <%= f.text_area :body, rows: 1, placeholder: "スポットの雰囲気、特徴や魅力などを記入してください（例：デートスポットにぴったり！）", class: "textarea textarea-bordered w-full" %>
     </div>
 
     <%# 画像 %>
     <div class="form-group">
-      <%= f.label :image, class: "form-label" do %>
+      <%= f.label :image, class: "form-label", for: :spot_image do %>
         画像 <span class="bg-red-700 text-xs ml-1 text-white rounded p-1">必須</span>
       <% end %>
-      <%= f.file_field :image, class: "w-full file-input file-input-primary" %>
+      <%= f.file_field :image, accept: 'image/*', class: "w-full file-input file-input-primary" %>
 
       <%# 画像プレビュー %>
       <% if spot.persisted? && spot.image.attached? %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Spots" %>
+<% content_for :title, "投稿一覧" %>
 
 <%= render 'search_form', q: @q, url: spots_path %>
 

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -821,6 +821,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1743965618
+    "timestamp": 1744014613
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-07T03:53:38+09:00">2025-04-07T03:53:38+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-07T17:30:13+09:00">2025-04-07T17:30:13+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
# 作業内容
## 入力フォームの内容を変更
- [x] `app/views/spots/_form.html.erb`を以下のように編集
  - 各項目ラベルにアクセシビリティ向上の`for`タグを付与
  - `placeholder`を変更
  - `url`のパターンの属性を簡略化
  - 説明の入力欄を削減
  - `image`に受け入れる形式を限定する属性を追加