### PR TITLE
fix:記入削除後も入力補完が表示されてしまう現象の修正

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
 
   async search() {
     // console.log('✅searchメソッドが呼ばれました') //デバッグ用
+    const query = this.inputTarget.value.trim();
 
     try {
       const query = this.inputTarget.value;


### PR DESCRIPTION
# 作業内容
- [x] `app/javascript/controllers/autocomplete_controller.js`を以下のように編集
  - ユーザーが入力した文字列から前後の空白（スペース・改行など）を取り除いた値を`query`という変数に代入する処理を記述


  ```js
  const query = this.inputTarget.value.trim();
  ```
