### PR TITLE
Feature/kaminari infinite scroll

### DIFF
--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -18,15 +18,17 @@
   <% end %>
 </div>
 
-<div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
+<%= turbo_frame_tag "spots-page-#{@spots.current_page}" do %>
   <% if @spots.any? %>
-    <%= render @spots %>
+    <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
+      <%= render @spots %>
+    </div>
+
+    <%= turbo_frame_tag "spots-page-#{@spots.next_page}", loading: :lazy, src: path_to_next_page(@spots) %>
   <% else %>
     <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
   <% end %>
-</div>
-
-<%= paginate @spots %>
+<% end %>
 
 <div class="mx-auto w-3/5 mt-5">
   <%= back_button %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 9
+  config.default_per_page = 15
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -839,6 +839,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1744108002
+    "timestamp": 1744223232
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-08T19:26:42+09:00">2025-04-08T19:26:42+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-10T03:27:12+09:00">2025-04-10T03:27:12+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
# 作業内容

## ビュー

- [x]  `app/views/spots/index.html.erb`を編集
- 遅延読み込みを行うために、`turbo_frame_tag`で`src`オプションを使用
    - `loading`オプションに`lazy`を指定すると、ページロード後ではなく、スクロールなどにより`<turbo-frame>`が画面に表示された時にTurbo Frameリクエストする。
- 以下の`<turbo-frame "spots-page-2">`まで画面をスクロールする。すると遅延ローディングにより`/spots?page=2`へTurbo Frameリクエストが実行される。

```html
<%= turbo_frame_tag "spots-page-#{@spots.current_page}" do %>
  <% if @spots.any? %>
    <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
      <%= render @spots %>
    </div>

    <%= turbo_frame_tag "spots-page-#{@spots.next_page}", loading: :lazy, src: path_to_next_page(@spots) %>
  <% else %>
    <p class="text-center my-10 col-span-3"><%= t('spots.index.no_spots') %></p>
  <% end %>
<% end %>
```

## `kaminari`の設定を変更

- [x]  `config/initializers/kaminari_config.rb` の設定を変更
- 表示されるアイテム数を増やす

```ruby
# frozen_string_literal: true

Kaminari.configure do |config|
  config.default_per_page = 15
  # config.max_per_page = nil
  # config.window = 4
  # config.outer_window = 0
  # config.left = 0
  # config.right = 0
  # config.page_method_name = :page
  # config.param_name = :page
  # config.max_pages = nil
  # config.params_on_first_page = false
end

```

# 備考

- https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-3#%E7%84%A1%E9%99%90%E3%82%B9%E3%82%AF%E3%83%AD%E3%83%BC%E3%83%AB%E3%81%AE%E5%AE%9F%E8%A3%85