### PR TITLE
fix:Content missingと表示されないように

### DIFF
--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -23,14 +23,15 @@
 
     <!-- 下部ボタン部 -->
     <div class="card-actions justify-end">
-      <%= link_to spot_path(spot, anchor: "comment_form"), class: "btn btn-secondary", data: { action: "click->loading#show" } do %>
+      <%= link_to spot_path(spot, anchor: "comment_form"), class: "btn btn-secondary", data: { action: "click->loading#show", turbo_frame: "_top" } do %>
         <svg class="h-6 w-6 text-slate-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
         </svg>
         <%= spot.comments.count %>
       <% end %>
+
       <%= render 'spots/bookmark_buttons', { spot: spot } %>
-      <%= link_to "詳細", spot, class: "btn btn-primary", data: { action: "click->loading#show" } %>
+      <%= link_to "詳細", spot, class: "btn btn-primary", data: { action: "click->loading#show", turbo_frame: "_top" } %>
     </div>
   </div>
 

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -836,6 +836,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1744230936
+    "timestamp": 1744231872
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-10T05:35:36+09:00">2025-04-10T05:35:36+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-10T05:51:12+09:00">2025-04-10T05:51:12+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
# 作業内容
## 一覧ページで「Content missing」と表示される件
- [x] `app/views/spots/_spot.html.erb`を以下のように編集
  - 以下のような、`turbo_frame: "_top"`を指定しないと、部分更新を期待するTurboが反応して「中身がないよ」と返ってくる。
  - 各ボタンに属性を付与

  ```html
  data: { turbo_frame: "_top" }
  ```