### PR TITLE
add:詳細画面におけるお気に入りボタンの配置を改善

### DIFF
--- a/app/views/spots/_bookmark.html.erb
+++ b/app/views/spots/_bookmark.html.erb
@@ -1,13 +1,13 @@
 <% if user_signed_in? %>
   <% if spot.bookmarked_by?(current_user) %>
-    <%= link_to spot_bookmarks_path(spot_id: spot.id), id: "spot_#{spot.id}_bookmark", data: { turbo_method: :delete }, class: "btn btn-primary" do %>
+    <%= link_to spot_bookmarks_path(spot_id: spot.id), id: "spot_#{spot.id}_bookmark", data: { turbo_method: :delete }, class: "btn btn-primary w-full" do %>
       <svg class="h-4 w-4 text-slate-900" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
       </svg>
       <%= spot.bookmarks.count %>
     <% end %>
   <% else %>
-    <%= link_to spot_bookmarks_path(spot_id: spot.id), id: "spot_#{spot.id}_bookmark", data: { turbo_method: :post }, class: "btn btn-neutral" do %>
+    <%= link_to spot_bookmarks_path(spot_id: spot.id), id: "spot_#{spot.id}_bookmark", data: { turbo_method: :post }, class: "btn btn-neutral w-full" do %>
       <svg class="h-4 w-4 text-slate-200" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
       </svg>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -3,9 +3,6 @@
 <!-- スポット名 + ブックマークボタン -->
 <div class="flex items-center justify-start px-3 py-3">
   <h1 class="font-bold text-4xl"><%= @spot.name %></h1>
-  <div class="ml-2">
-    <%= render 'spots/bookmark_buttons', { spot: @spot } %>
-  </div>
 </div>
 
 <div class="grid grid-cols-3">
@@ -95,6 +92,11 @@
               </svg>
               <span><%= t('.share') %></span>
             <% end %>
+          </td>
+        </tr>
+        <tr>
+          <td class="border border-gray-800" colspan="2">
+            <%= render 'spots/bookmark_buttons', { spot: @spot } %>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
#作業内容
##詳細画面のお気に入りボタンの配置を変更
- [x] `app/views/spots/_bookmark.html.erb`を以下のように編集
  - 各お気に入りボタンのスタイル自体を変更（w-full追加）
  ```html
  class: "btn btn-primary w-full"
  ```
- [x] `app/views/spots/show.html.erb`を以下のように変更
  - お気に入りボタンをテーブル内に移動