### PR TITLE
Style:footerが吊り上がってしまう問題の修正

### DIFF
--- a/app/views/diagnoses/result.html.erb
+++ b/app/views/diagnoses/result.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t('.title') %>
+
 <div class="mx-auto w-1/3 my-8">
 
   <h2 class="text-2xl font-bold mb-6 text-center">あなたへのオススメ夜景スポット</h2>
@@ -20,8 +22,10 @@
       <% end %>
     </div>
   <% else %>
-    <div class="alert alert-info my-4">
+    <div class="alert alert-info my-8">
       条件に合うスポットが見つかりませんでした。条件を変更して再度お試しください。
+    </div>
+    <div class="block">
       <%= back_button %>
     </div>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   </head>
 
   <body class="flex flex-col min-h-screen bg-gray-800">
-    <div data-controller="loading">
+    <div data-controller="loading" class="min-h-screen flex flex-col">
       <div data-loading-target="infinity" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
         <div class="h-[150px] w-[150px] flex items-center justify-center">
           <span class="loading loading-infinity text-default w-full h-full"></span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,17 +1,6 @@
-<footer class="footer footer-center bg-base-200 text-base-content rounded p-10 mt-12">
-  <nav class="grid grid-flow-col gap-4">
-    <%= link_to t('footer.contact'), "https://forms.gle/PSBY2iA6keoDJm416",
-                class: "link link-hover",
-                target: "_blank",
-                rel: "noopener noreferrer" %>
-    <%= link_to t('footer.terms'), terms_path,
-                class: "link link-hover",
-                data: { action: "click->loading#show" } %>
-    <%= link_to t('footer.privacy_policy'), "https://kiyac.app/privacypolicy/qO1wEtf0KvWQzyLaRJGK",
-                class: "link link-hover",
-                target: "_blank",
-                rel: "noopener noreferrer" %>
-  </nav>
+<footer class="footer footer-center bg-base-100 text-base-content rounded p-10 mt-12 bottom-0 w-full">
+
+  <%# 開発者アイコン系 %>
   <nav>
     <div class="grid grid-flow-col gap-4">
       <a href="https://x.com/hisa_dev">
@@ -38,6 +27,23 @@
       </a>
     </div>
   </nav>
+
+  <%# コンタクト系 %>
+  <nav class="grid grid-flow-col gap-4">
+    <%= link_to t('footer.contact'), "https://forms.gle/PSBY2iA6keoDJm416",
+                class: "link link-hover",
+                target: "_blank",
+                rel: "noopener noreferrer" %>
+    <%= link_to t('footer.terms'), terms_path,
+                class: "link link-hover",
+                data: { action: "click->loading#show" } %>
+    <%= link_to t('footer.privacy_policy'), "https://kiyac.app/privacypolicy/qO1wEtf0KvWQzyLaRJGK",
+                class: "link link-hover",
+                target: "_blank",
+                rel: "noopener noreferrer" %>
+  </nav>
+
+  <%# コピーライト %>
   <aside>
     <% if Time.current.year == 2025 %>
       <p>© <%= Time.current.year %> NighTrip. All rights reserved.</p>

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -949,6 +949,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1744609275
+    "timestamp": 1744675663
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-14T14:41:15+09:00">2025-04-14T14:41:15+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-04-15T09:07:43+09:00">2025-04-15T09:07:43+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
# 作業内容
## 診断結果の画面でフッターが上がりきってしまう
- [x] `app/views/layouts/application.html.erb`を以下のように編集
  - headerとmainとfooterを同一階層に整理し、それらの親要素に対して縦で子要素が表示されるように変更
## 開発者アイコンの位置を調整
- [x] `app/views/shared/_footer.html.erb`を以下のように編集
  - GithubやXのアカウントアイコンを上部に配置
## 修正したfooterのスタイルとの関係部を修正
- [x] `app/views/diagnoses/result.html.erb`を以下のように編集
  - 戻るボタンがフッター上に正常に表示されるように