### PR TITLE
Fix:spotカードのタグをクリックすると、ローディングアニメーションが表示されないように修正

### DIFF
--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -19,7 +19,7 @@
     <!-- タグ部 -->
     <div class="flex flex-wrap gap-2 my-2">
       <% spot.tags.each do |tag| %>
-        <%= link_to tag.name, spots_path(q: { tags_name_eq: tag.name }), class: "badge badge-outline", data: { action: "click->loading#show" } %>
+        <%= link_to tag.name, spots_path(q: { tags_name_eq: tag.name }), class: "badge badge-outline" %>
       <% end %>
     </div>
 


### PR DESCRIPTION
# 作業内容
## スポットのカードのタグをクリックすると、ローディングアニメーションが終わらないバグ
- [x] `app/views/spots/_spot.html.erb`を以下のように編集
  - タグの表示部分で、ローディングアニメーションの`data-action`属性を削除