### PR TITLE
Style:アプリの背景色に合わないコメントのカラーを修正

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,16 +1,2 @@
 module CommentsHelper
-  def comment_class(chat_color)
-    case chat_color.presence || "デフォルト"
-    when "デフォルト" then "bg-neutral text-base-content"
-    when "エナジー"   then "bg-primary text-primary-content"
-    when "カーム"     then "bg-secondary text-secondary-content"
-    when "ポップ"     then "bg-accent text-accent-content"
-    when "フレッシュ" then "bg-success text-success-content"
-    when "インフォ"   then "bg-info text-info-content"
-    when "サニー"     then "bg-warning text-warning-content"
-    when "アラート"   then "bg-error text-error-content"
-    else
-      "bg-neutral text-base-content"
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,6 @@ class User < ApplicationRecord
   end
 
   def set_default_chat_color
-    self.chat_color ||= "default"
+    self.chat_color ||= "energy"
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -6,9 +6,8 @@
       <time class="text-xs opacity-50 ml-2"><%= comment.created_at.in_time_zone("Tokyo").strftime("%Y/%m/%d %H:%M") %></time>
     </div>
 
-    <% chat_color = comment.user.chat_color.presence || 'default' %>
+    <% chat_color = comment.user.chat_color.presence || 'energy' %>
     <% color_class = case chat_color
-      when 'default' then "bg-neutral text-base-content"
       when 'energy'  then "bg-primary text-primary-content"
       when 'calm'    then "bg-secondary text-secondary-content"
       when 'pop'     then "bg-accent text-accent-content"
@@ -17,7 +16,7 @@
       when 'sunny'   then "bg-warning text-warning-content"
       when 'alert'   then "bg-error text-error-content"
       else
-        "bg-neutral text-base-content"
+        "bg-primary text-primary-content"
       end %>
 
     <div class="chat-bubble break-words <%= color_class %>">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,7 +22,6 @@
         <%= f.select :chat_color,
           options_for_select(
             [
-              [t('activerecord.attributes.user.chat_color_values.default'), 'default'],
               [t('activerecord.attributes.user.chat_color_values.energy'), 'energy'],
               [t('activerecord.attributes.user.chat_color_values.calm'), 'calm'],
               [t('activerecord.attributes.user.chat_color_values.pop'), 'pop'],
@@ -37,9 +36,8 @@
       </div>
 
       <!-- コメントのプレビュー -->
-      <% chat_color = current_user.chat_color.presence || 'default' %>
+      <% chat_color = current_user.chat_color.presence || 'energy' %>
       <% color_class = case chat_color
-        when 'default' then "bg-neutral text-base-content"
         when 'energy'  then "bg-primary text-primary-content"
         when 'calm'    then "bg-secondary text-secondary-content"
         when 'pop'     then "bg-accent text-accent-content"
@@ -48,7 +46,7 @@
         when 'sunny'   then "bg-warning text-warning-content"
         when 'alert'   then "bg-error text-error-content"
         else
-          "bg-neutral text-base-content"
+          "bg-primary text-primary-content"
         end %>
 
       <div class="my-4">


### PR DESCRIPTION
# 作業内容
## 背景色の変更によって見にくくなったコメントの背景色のデフォルトを修正
- [x] `app/models/user.rb`を以下のように編集
  - デフォルトのコメント背景色を`default`から`energy`へ
- [x] `app/views/profiles/show.html.erb`を以下のように編集
  - デフォルトのコメント背景色を`default`から`energy`へ
- [x] `app/views/comments/_comment.html.erb`を以下のように編集
  - デフォルトのコメント背景色を`default`から`energy`へ
  - コメントの選択肢から`default`を削除
## 不要になったhelpersの内容を消去
- [x] `app/helpers/comments_helper.rb`を以下のように編集
  - コメントの動的処理は、tailwindの仕様上読み込まれないので、削除