### PR TITLE
refact:一覧画面のコードを見やすく修正

### DIFF
--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,13 +1,16 @@
+<%# Page title  %>
 <% content_for :title, t('.title') %>
 
+<%# Search Form %>
 <%= render 'search_form', q: @q, url: spots_path %>
 
+<%# Link button to view #NighTrip posts on X (Twitter) %>
 <div class="flex justify-center mt-4">
   <%= link_to "https://x.com/hashtag/NighTrip?src=hashtag_click&f=live",
               target: '_blank',
               rel: 'noopener noreferrer',
               class: "btn btn-outline btn-md text-sky-400 border-sky-300 hover:bg-sky-100 transition duration-150",
-              "aria-label": "Xでみんなの投稿を見る" do %>
+              "aria-label": t('.checkout_others_posts_on_X') do %>
     <svg class="h-8 w-8 mr-2 text-sky-400"
          xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
          stroke="currentColor" stroke-width="2">
@@ -18,6 +21,7 @@
   <% end %>
 </div>
 
+<%# Spot list %>
 <%= turbo_frame_tag "spots-page-#{@spots.current_page}" do %>
   <% if @spots.any? %>
     <div class="grid sm:grid-cols-3 gap-5 md:gap-8 my-8">
@@ -30,6 +34,7 @@
   <% end %>
 <% end %>
 
+<%# Back button to return to the previous page %>
 <div class="mx-auto w-3/5 mt-5">
   <%= back_button %>
 </div>


### PR DESCRIPTION
## 作業内容
各部をコメントアウトで区切り、視認性を向上
 - `app/views/spots/index.html.erb`を以下のように編集
 - [x] 各部ごとにコメントを追記
 - [x] 「みんなの投稿をXで見てみる」ボタンのaria-label属性をi18n化して統一

## 参考文献
- [【MDN】 aria-label](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
- [【Qiita】 aria-labelの適切な利用について調べてみた](https://qiita.com/gilly/items/704680d57aba1381e9d0)
- [【個人ブログ】 知っていると便利なaria-label属性の使い方](https://www.ofujimiki.jp/2015/11/04/aria-label/)