### PR TITLE
add:TOPへ戻るボタンを実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("hello", HelloController)
 import LoadingController from "./loading_controller"
 application.register("loading", LoadingController)
 
+import ScrollToTopController from "./scroll_to_top_controller"
+application.register("scroll-to-top", ScrollToTopController)
+
 import StepFormController from "./step_form_controller"
 application.register("step-form", StepFormController)
 

--- a/app/javascript/controllers/scroll_to_top_controller.js
+++ b/app/javascript/controllers/scroll_to_top_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="scroll-to-top"
+export default class extends Controller {
+    static targets = ["button"]
+
+  connect() {
+    this._toggleButtonHandler = this.toggleButton.bind(this)
+    window.addEventListener("scroll", this._toggleButtonHandler)
+  }
+
+
+  disconnect() {
+    window.removeEventListener("scroll", this._toggleButtonHandler)
+  }
+
+  toggleButton() {
+    if (window.scrollY > 300) {
+      this.buttonTarget.classList.remove("hidden")
+    } else {
+      this.buttonTarget.classList.add("hidden")
+    }
+  }
+
+  scrollToTop() {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    })
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,14 +80,29 @@
 
       <%= render 'shared/footer' %>
 
-      <%# Floating Action Button %>
-      <%= link_to new_spot_path, class: "btn btn-primary btn-circle fixed bottom-10 right-10 z-50 shadow-lg h-14 w-14" do %>
+      <%# Floating Action Button for New Spot %>
+      <%= link_to new_spot_path, class: "btn btn-primary btn-circle fixed bottom-10 right-10 z-50 shadow-lg h-14 w-14 hover:scale-110" do %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none"
             viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M12 4v16m8-8H4"/>
         </svg>
       <% end %>
+
+      <%# Scroll to Top Button %>
+      <div data-controller="scroll-to-top">
+        <button
+          data-scroll-to-top-target="button"
+          data-action="click->scroll-to-top#scrollToTop"
+          class="btn btn-primary btn-circle fixed bottom-28 right-10 z-50 shadow-lg h-14 w-14 hidden transition duration-300 ease-in-out hover:scale-110"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none"
+              viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M5 15l7-7 7 7" />
+          </svg>
+        </button>
+      </div>
 
     </div>
   </body>

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -943,6 +943,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1750606183
+    "timestamp": 1751441490
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-06-23T00:29:43+09:00">2025-06-23T00:29:43+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-07-02T16:31:30+09:00">2025-07-02T16:31:30+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
## ✅ 概要 / Summary

「TOPへ戻るボタン」を Stimulus を使って実装する。  
ユーザーがスクロールした際にボタンを表示し、クリックでスムーズにページトップへ戻る機能を提供する。

参考記事:  
[Javascriptのみで作るトップに戻るボタン(rails,haml)](https://qiita.com/s79ns/items/4a019ebecfb3acb0547c)

---

## 🔧 タスク / Tasks

### Stimulus コントローラ作成

- [x] 以下のコマンドでコントローラ作成  
  ```bash
  bin/rails generate stimulus scroll_to_top
  ```

### scroll_to_top_controller.js の実装

- [x] target を定義
- [x] スクロール量の閾値（例: 300px）を設定
- [x] スムーズなアニメーションでスクロール

### application.html.erb の修正

- [x] `data-controller="scroll-to-top"` を指定
- [x] ページ内にトップへ戻るボタンを配置
- [x] ボタンに `data-scroll-to-top-target="button"` を付与

---

## 💡 補足 / Notes

- Tailwind CSS や daisyUI を利用して、ボタンのデザインを調整予定
- Stimulus の target でボタン表示／非表示を制御