### PR TITLE
add:診断機能UIを改善

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,10 +27,10 @@ module ApplicationHelper
 
   # == Buttons ==
   def back_button(label = t("helpers.label.back"))
-    link_to label, :back, class: "btn btn-base w-full", data: { action: "click->loading#show" }
+    link_to label, :back, class: "btn btn-base w-full hover:bg-gray-600", data: { action: "click->loading#show" }
   end
 
   def spots_index_button(label = t("helpers.label.spots_index"))
-    link_to label, spots_path, class: "btn btn-primary w-full", data: { action: "click->loading#show" }
+    link_to label, spots_path, class: "btn btn-primary w-full hover:bg-gray-600", data: { action: "click->loading#show" }
   end
 end

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -1,8 +1,10 @@
 <% content_for :title, t('.title') %>
 
+<!--
 <h1 class="text-2xl font-bold text-center"><%= t('.title') %></h1>
+-->
 
-<%= form_with url: diagnosis_result_path, method: :post, data: { controller: "step-form" }, class: "my-4" do |f| %>
+<%= form_with url: diagnosis_result_path, method: :post, data: { controller: "step-form" }, class: "my-2" do |f| %>
 
   <!-- ステップバー -->
   <ul class="steps w-full mb-4" data-step-form-target="progress">
@@ -13,11 +15,15 @@
 
   <!-- ステップ1：地域 -->
   <div data-step-form-target="step" class="card p-6 bg-base-100 shadow-md w-2/5 mx-auto space-y-2">
-    <%= f.label :region, "STEP1：地域を選んでください", class: "block text-center text-lg font-semibold mb-2" %>
+    <div>
+      <%= f.label :region, "STEP1：地域を選んでください", class: "block text-center font-zenmaru text-lg mb-6 sm:text-xl font-semibold text-center mb-2" %>
+    </div>
     <%= f.collection_radio_buttons :region, @region_options, :last, :first do |b| %>
-      <label class="label cursor-pointer flex items-center gap-2">
-        <%= b.radio_button(class: "radio", required: true) %>
-        <%= b.text %>
+      <label class="block cursor-pointer">
+        <%= b.radio_button(class: "hidden peer", required: true) %>
+        <div class="btn btn-soft btn-primary bg-base-100 w-full text-left justify-start px-4 py-2 rounded-full text-white shadow-md peer-checked:bg-primary-focus peer-checked:bg-primary">
+          <%= b.text %>
+        </div>
       </label>
     <% end %>
     <div>
@@ -27,27 +33,31 @@
 
   <!-- ステップ2：雰囲気 -->
   <div data-step-form-target="step" style="display: none;" class="card p-6 bg-base-100 shadow-md w-2/5 mx-auto space-y-2">
-    <%= f.label :atmosphere, "STEP2：雰囲気を選んでください", class: "block text-center form-label text-lg font-semibold mb-2 " %>
+    <div>
+      <%= f.label :atmosphere, "STEP2：雰囲気を選んでください", class: "block text-center font-zenmaru mb-6 text-lg sm:text-xl font-semibold text-center mb-2" %>
+    </div>
     <%= f.collection_radio_buttons :atmosphere, Spot::ATMOSPHERE_OPTIONS, :to_s, :to_s do |b| %>
-      <label class="label cursor-pointer flex items-center gap-2">
-        <%= b.radio_button(class: "radio", required: true) %>
-        <%= b.text %>
+      <label class="block cursor-pointer">
+        <%= b.radio_button(class: "hidden peer", required: true) %>
+        <div class="btn btn-soft btn-primary bg-base-100 w-full text-left justify-start px-4 py-2 rounded-full text-white shadow-md peer-checked:bg-primary-focus peer-checked:bg-primary">
+          <%= b.text %>
+        </div>
       </label>
     <% end %>
-    <div class="mt-5 flex justify-between">
-      <%= tag.button t('helpers.button.back'), type: 'button', data: { action: 'step-form#back' }, class: 'btn btn-outline' %>
-      <%= tag.button t('helpers.button.next'), type: 'button', data: { action: 'step-form#next' }, class: 'btn btn-primary' %>
+    <div class="flex justify-between">
+      <%= tag.button t('helpers.button.back'), type: 'button', data: { action: 'step-form#back' }, class: 'btn btn-outline mt-4' %>
+      <%= tag.button t('helpers.button.next'), type: 'button', data: { action: 'step-form#next' }, class: 'btn btn-primary mt-4' %>
     </div>
   </div>
 
+
   <!-- ステップ3：特徴 -->
-  <div data-step-form-target="step" style="display: none;" class="card p-6 bg-base-100 shadow-md w-2/5 mx-auto">
-
-    <%= f.label :tag, "STEP3：特徴（タグ）を1つ選んでください", class: "block text-center form-label text-lg font-semibold mb-2" %>
-
+  <div data-step-form-target="step" style="display: none;" class="card p-6 bg-base-100 shadow-md w-2/5 mx-auto space-y-2">
+    <div>
+      <%= f.label :tag, "STEP3：特徴（タグ）を1つ選んでください", class: "block text-center form-label text-lg mb-6 font-semibold mb-2" %>
+    </div>
     <div data-controller="autocomplete"
         data-autocomplete-url-value="<%= autocomplete_tags_path %>">
-
       <%= f.text_field :tag,
             data: {
               "autocomplete-target": "input"
@@ -55,7 +65,6 @@
             class: "input input-bordered w-full",
             placeholder: "タグを入力してください",
             required: true %>
-
       <ul data-autocomplete-target="results"
           class="bg-gray-700 absolute rounded mt-1 w-full max-w-max max-h-60 overflow-auto z-50">
       </ul>
@@ -65,7 +74,7 @@
       <p class="mb-2">人気のタグ</p>
       <div class="flex flex-wrap gap-3" data-controller="tag-select">
         <% @popular_tags.each do |tag| %>
-          <span class="badge badge-outline cursor-pointer"
+          <span class="badge badge-outline hover:bg-gray-600 hover:text-white cursor-pointer transition"
                 data-action="click->tag-select#select"
                 data-tag-select-name-value="<%= tag.name %>">
             <%= tag.name %>
@@ -74,9 +83,9 @@
       </div>
     </div>
 
-    <div class="mt-5 flex justify-between">
-      <%= tag.button t('helpers.button.back'), type: 'button', data: { action: 'step-form#back' }, class: 'btn btn-outline' %>
-      <%= f.submit "診断する", class: "btn btn-success", data: { turbo: false } %>
+    <div class="flex justify-between">
+      <%= tag.button t('helpers.button.back'), type: 'button', data: { action: 'step-form#back' }, class: 'btn btn-outline mt-4' %>
+      <%= f.submit "診断する", class: "btn btn-success mt-4", data: { turbo: false } %>
     </div>
   </div>
 

--- a/app/views/diagnoses/result.html.erb
+++ b/app/views/diagnoses/result.html.erb
@@ -9,7 +9,7 @@
       <% @spots.each do |spot| %>
         <div class="my-4">
           <%= render spot %>
-          <%= link_to "https://x.com/intent/tweet?text=#{CGI.escape("夜景診断：あなたへのオススメ夜景スポットは、【#{spot.name}】です！\n\n夜景詳細情報\nスポット名：#{spot.name}\n位置情報：#{spot.prefecture.name + spot.address}\n投稿者：#{spot.user.name}\n\n#{request.url}\n#NighTrip #夜景 #夜景診断")}", target: '_blank', class: "btn btn-base flex item-center gap-2 my-5" do %>
+          <%= link_to "https://x.com/intent/tweet?text=#{CGI.escape("夜景診断：あなたへのオススメ夜景スポットは、【#{spot.name}】です！\n\n夜景詳細情報\nスポット名：#{spot.name}\n位置情報：#{spot.prefecture.name + spot.address}\n投稿者：#{spot.user.name}\n\n#{request.url}\n#NighTrip #夜景 #夜景診断")}", target: '_blank', class: "btn btn-base flex item-center gap-2 my-5 hover:bg-gray-600" do %>
             <svg class="h-6 w-6 text-slate-200" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
               <path d="M4 4l11.733 16h4.267l-11.733 -16z" />

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -943,6 +943,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1751441490
+    "timestamp": 1751459423
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-07-02T16:31:30+09:00">2025-07-02T16:31:30+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-07-02T21:30:23+09:00">2025-07-02T21:30:23+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -7425,7 +7425,7 @@
 
             
 
-            <code class="ruby">    link_to label, :back, class: &quot;btn btn-base w-full&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
+            <code class="ruby">    link_to label, :back, class: &quot;btn btn-base w-full hover:bg-gray-600&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
           </li>
         </div>
       
@@ -7469,7 +7469,7 @@
 
             
 
-            <code class="ruby">    link_to label, spots_path, class: &quot;btn btn-primary w-full&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
+            <code class="ruby">    link_to label, spots_path, class: &quot;btn btn-primary w-full hover:bg-gray-600&quot;, data: { action: &quot;click-&gt;loading#show&quot; }</code>
           </li>
         </div>
       


### PR DESCRIPTION
## ✅ 概要 / Summary

診断ステップUIの改善を行う。  
現在の3ステップフォーム（地域・雰囲気・特徴）のUIに一貫性と洗練された視覚表現を追加し、ユーザー体験の向上を図る。

---

## 🔧 タスク / Tasks

### ✅ タイトルの整理

- [x] ステップページ上部のタイトルは重複しているため、削除または見直し

### 🗾 ステップ1：地域選択
- [x] `collection_radio_buttons` の選択肢で、`peer` クラスによる選択状態表示を反映
- [x] `peer-checked:bg-primary` などによる視覚的な強調スタイルを適用
- [x] 選択肢をボタン風に（`btn`, `rounded-full` など）

### 🎭 ステップ2：雰囲気選択
- [x] 地域と同様に `collection_radio_buttons` の視覚的改善
- [x] `peer-checked` による選択状態の反映と視覚強調
- [x] STEP1と統一感あるレイアウトとパディング

### 🏷 ステップ3：特徴（タグ）選択
- [x] `@popular_tags` の表示タグに `hover` スタイルを追加して視認性を高める
- [x] スペースと階層構造（ラベル・入力欄・タグリスト）の整理

### 📄 診断結果ページ
- [x] `app/views/diagnoses/result.html.erb` にあるボタンの `hover` スタイル調整
- [x] 成果ページにおけるフォントとパディングの統一

### 🧩 共通スタイル調整
- [x] 質問文と選択肢とのスペース（`mt-5`, `mb-4`など）を全体的に統一
- [x] ボタンの上下余白・配置位置を3ステップで統一
- [x] STEP下部にあるボタンと選択肢の間のスペースを明確に分ける

### 🛠 カスタムヘルパー
- [x] `application_helper.rb` 内で共通ヘルパーを見直し

---

## 💡 補足 / Notes

- Tailwind CSS + daisyUI をベースとした一貫性のあるデザイン調整を優先
- `peer`, `peer-checked`, `hover`, `transition`, `shadow` などのユーティリティを活用

---

## 🔗 関連ファイル / Related Files

- `app/views/diagnoses/new.html.erb`
- `app/views/diagnoses/result.html.erb`
- `app/helpers/application_helper.rb`
- `app/javascript/controllers/step_form_controller.js`
- `app/javascript/controllers/autocomplete_controller.js`
- `app/javascript/controllers/tag_select_controller.js`