### PR TITLE
add: SDD開発体制（GitHub Mobile対応）の基盤を構築

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: "Bug Report"
+description: "バグを報告する"
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: "何が起きた？"
+      description: "簡潔に説明してください"
+      placeholder: "例: スポット投稿時に画像アップロードが失敗する"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "期待する動作"
+      placeholder: "例: 画像が正常にアップロードされてスポットが作成される"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "深刻度"
+      options:
+        - "致命的（サイトが使えない）"
+        - "高（主要機能が壊れている）"
+        - "中（回避策あり）"
+        - "低（見た目の問題）"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "再現手順（任意）"
+      placeholder: |
+        1. ○○ページを開く
+        2. ○○ボタンをクリック
+        3. エラーが表示される
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: "スクリーンショット（任意）"
+      description: "画像をドラッグ＆ドロップで添付"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "NighTrip サイト"
+    url: https://nightrip.net/
+    about: "NighTrip 本番サイト"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,48 @@
+name: "Feature Request"
+description: "新しい機能を提案する"
+title: "[Feature] "
+labels: ["proposal"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "やりたいこと"
+      description: "1行でOK。何を実現したいかを書いてください。"
+      placeholder: "例: スポット詳細ページにLINEシェアボタンを追加したい"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先度"
+      options:
+        - "高（すぐ欲しい）"
+        - "中（次のスプリント）"
+        - "低（いつか）"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: "カテゴリ"
+      options:
+        - "UI/UX改善"
+        - "新機能"
+        - "SEO"
+        - "パフォーマンス"
+        - "セキュリティ"
+        - "インフラ"
+        - "その他"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "補足（任意）"
+      description: "参考URL、スクリーンショット、詳細な要件など"
+      placeholder: "任意: 追加情報があれば"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,35 @@
+name: "Maintenance"
+description: "メンテナンス・リファクタリングタスク"
+title: "[Chore] "
+labels: ["maintenance"]
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: "タスク内容"
+      description: "何をしたいか簡潔に"
+      placeholder: "例: Dependabotの未対応PRを整理したい"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: "種類"
+      options:
+        - "依存関係の更新"
+        - "リファクタリング"
+        - "CI/CD改善"
+        - "ドキュメント"
+        - "テスト追加"
+        - "セキュリティ対応"
+        - "その他"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: "補足（任意）"
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-updates:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR do? Link the related issue. -->
+
+Closes #
+
+## Changes
+
+-
+
+## Test Plan
+
+- [ ] `bundle exec rspec` passes
+- [ ] `bin/rubocop` passes
+- [ ] `bin/brakeman --no-pager` passes
+- [ ] Manual verification (if applicable)
+
+## Screenshots (if UI change)
+
+<!-- Drag & drop screenshots here -->

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,41 @@
+name: Auto-merge Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label minor updates for review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr edit "$PR_URL" --add-label "needs-review"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-review"
+          gh pr comment "$PR_URL" --body "⚠️ **Major version update** — manual review required before merge."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager --no-ensure-latest --ignore-config .brakeman.ignore
+        run: bundle exec brakeman --no-pager --ignore-config .brakeman.ignore
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager --ignore-config .brakeman.ignore
+        run: bin/brakeman --no-pager --no-ensure-latest --ignore-config .brakeman.ignore
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,51 @@
+name: Claude Code
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Trigger on 'approved' label OR on comment containing @claude
+    if: |
+      (github.event_name == 'issues' && github.event.label.name == 'approved') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-sonnet-4-20250514"
+          allowed_tools: "Bash,Read,Write,Edit,Glob,Grep"
+          max_turns: 50
+
+      - name: Update issue labels
+        if: success()
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --remove-label "approved" \
+            --add-label "in-progress"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md — NighTrip Development Guide
+
+## Project Overview
+
+NighTrip (https://nightrip.net/) is a night-view spot sharing web application.
+
+**Tech Stack:** Rails 7.2 + Hotwire (Turbo/Stimulus) + Tailwind CSS / daisyUI + PostgreSQL
+**Hosting:** Render (Web + DB), AWS S3 (images)
+**APIs:** Google Maps JavaScript API, Google OAuth 2.0
+
+## Development Commands
+
+```bash
+# Setup
+bundle install
+yarn install
+bin/rails db:prepare
+
+# Run locally
+bin/dev
+
+# Tests
+bundle exec rspec                    # All tests
+bundle exec rspec spec/models/       # Model tests only
+bundle exec rspec spec/system/       # System tests only
+
+# Linting & Security
+bin/rubocop -f github                # RuboCop
+bin/brakeman --no-pager              # Security scan
+
+# Database
+bin/rails db:migrate
+bin/rails db:seed
+bin/rails db:rollback
+
+# Assets
+bin/rails assets:precompile RAILS_ENV=test
+```
+
+## Architecture
+
+```
+app/
+├── controllers/    # Rails controllers (RESTful)
+├── models/         # ActiveRecord models
+├── views/          # ERB templates + Turbo Frames/Streams
+├── javascript/     # Stimulus controllers
+├── helpers/        # View helpers
+├── mailers/        # Action Mailer
+└── assets/         # Stylesheets (Tailwind via cssbundling)
+
+config/
+├── routes.rb       # Routing definitions
+├── database.yml    # PostgreSQL config
+└── environments/   # Per-environment settings
+
+spec/
+├── models/         # Model specs (RSpec)
+├── system/         # System specs (Capybara + Selenium)
+├── factories/      # FactoryBot factories
+└── rails_helper.rb # RSpec configuration
+```
+
+## Key Models
+
+- `User` — Devise authentication + Google OAuth
+- `Spot` — Night-view spots with geolocation (lat/lng via Geocoder)
+- `Comment` — Spot comments (Turbo Streams for real-time)
+- `Bookmark` — User bookmarks for spots
+- `Tag` / `SpotTag` — Tagging system
+
+## Branching & Workflow
+
+### Branch Naming
+- Feature: `feature/issue-{number}-{slug}`
+- Bug fix: `fix/issue-{number}-{slug}`
+- Maintenance: `chore/issue-{number}-{slug}`
+
+### Development Workflow (SDD - Spec Driven Development)
+1. Check for Issues with `approved` label
+2. Create feature branch from `main`
+3. Write/update specs first, then implement
+4. Run full test suite: `bundle exec rspec`
+5. Run linter: `bin/rubocop -a` (auto-correct safe violations)
+6. Run security scan: `bin/brakeman --no-pager`
+7. Create PR with structured description
+8. Add `needs-review` label to PR
+9. After merge to `main`, Render auto-deploys
+
+### Label System
+| Label | Meaning |
+|-------|---------|
+| `approved` | User approved — start implementation |
+| `proposal` | Claude's proposal — awaiting user review |
+| `in-progress` | Implementation underway |
+| `needs-review` | PR ready for user review |
+| `auto-merge` | Auto-merge after CI passes |
+
+## CI/CD
+
+- **CI:** GitHub Actions (`.github/workflows/ci.yml`) — Brakeman + RuboCop + RSpec
+- **CD:** Render auto-deploys on `main` push
+- **Dependabot:** Weekly updates, auto-merge for patch versions
+
+## Environment Variables
+
+Required in production (Render):
+- `DATABASE_URL` — PostgreSQL connection string
+- `RAILS_MASTER_KEY` — Rails credentials decryption key
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — S3 image storage
+- `AWS_BUCKET` / `AWS_REGION` — S3 bucket config
+- `GOOGLE_MAPS_API_KEY` — Google Maps JavaScript API
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — Google OAuth
+
+## Coding Conventions
+
+- Follow existing Rails conventions and Rubocop rules (`.rubocop.yml`)
+- Use Hotwire (Turbo Frames/Streams + Stimulus) for interactivity — no heavy JS frameworks
+- Use daisyUI component classes for UI elements
+- Japanese UI text, English code/comments
+- Always write RSpec tests for new features
+- Keep controllers thin, models contain business logic


### PR DESCRIPTION
## Summary

GitHub Mobileからの指示だけで開発が回るSDD（Spec Driven Development）体制を構築。

## Changes

- **CLAUDE.md**: Claude Codeが自律的に開発するためのガイドファイル
- **Issue テンプレート** (YAML forms): GitHub Mobileでフォーム入力可能
  - `feature-request.yml` — 機能提案（1行 + 優先度 + カテゴリ）
  - `bug-report.yml` — バグ報告（深刻度 + 再現手順）
  - `maintenance.yml` — メンテナンスタスク
- **PR テンプレート**: 構造化されたPR説明フォーマット
- **GitHub Actions ワークフロー**:
  - `auto-merge-dependabot.yml` — patch自動マージ、minor/majorはレビュー通知
  - `claude-code.yml` — `approved`ラベルでClaude Code自動起動
- **Dependabot最適化**: daily→weekly、patch/minorグループ化
- **ラベルシステム**: approved, proposal, in-progress, needs-review, auto-merge

## ワークフロー

```
iPhone → Issue作成 → approvedラベル → Claude Code自動実装 → PR → レビュー → マージ → 自動デプロイ
```

## Test plan

- [ ] Issue テンプレートがGitHub Mobileで表示されること
- [ ] ラベルが正しく作成されていること
- [ ] CI（Brakeman + RuboCop + RSpec）がPR上で実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)