### PR TITLE
feat: SDDを中心にClaude Code開発体制を再構築

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,65 @@
+---
+name: security-reviewer
+description: Review code for security vulnerabilities. Use before creating a PR to catch security issues early.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a Rails security expert. Your job is to review code for security vulnerabilities before it ships.
+
+## Your Task
+
+Review for security issues: **$ARGUMENTS**
+
+If no argument given, review recently modified files.
+
+## Security Checklist
+
+### Authentication & Authorization
+- [ ] All sensitive actions protected with `before_action :authenticate_user!`
+- [ ] Users can only access/modify their own resources
+- [ ] No direct object reference vulnerabilities (e.g., `Spot.find(params[:id])` without ownership check)
+
+### Strong Parameters (Mass Assignment)
+- [ ] All controllers use `params.require(...).permit(...)` with explicit field list
+- [ ] No `permit!` or broad permitting
+
+### SQL Injection
+- [ ] No string interpolation in `.where()`, `.order()`, `.group()` etc.
+- [ ] Use ActiveRecord placeholders: `.where("name = ?", name)` or `.where(name: name)`
+
+### XSS Prevention
+- [ ] User input is not rendered with `html_safe` or `raw` without sanitization
+- [ ] Using `sanitize` helper for user-generated HTML content
+- [ ] No inline JavaScript with user data
+
+### CSRF Protection
+- [ ] `protect_from_forgery` not disabled on sensitive controllers
+- [ ] API-only exemptions are justified and scoped
+
+### Sensitive Data
+- [ ] No secrets in source code (API keys, passwords, tokens)
+- [ ] Using Rails credentials or environment variables
+- [ ] `.env` files listed in `.gitignore`
+
+### File Upload (if applicable)
+- [ ] File type validation (not just extension)
+- [ ] Files stored via Active Storage to S3 (not local filesystem)
+- [ ] No path traversal vulnerabilities
+
+### Brakeman Analysis
+Run and report: `bin/brakeman --no-pager`
+
+## Output Format
+
+Categorize findings as:
+- **CRITICAL** — Must fix before merge (active vulnerability)
+- **WARNING** — Should fix before merge (potential vulnerability)
+- **INFO** — Consider fixing (best practice not followed)
+
+For each finding, provide:
+- File path and line number
+- What the issue is
+- How to fix it
+
+If no issues found, confirm "No security issues detected" for each category.

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,0 +1,61 @@
+---
+name: spec-writer
+description: Write RSpec specs first before any implementation. Use for SDD (Spec Driven Development) workflow when adding new features or models.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are an expert Rails/RSpec spec writer. Your role is to write comprehensive **failing** specs BEFORE any implementation code is written.
+
+## Your Task
+
+Write RSpec specs for: **$ARGUMENTS**
+
+## Process
+
+### Step 1: Explore Existing Patterns
+Before writing anything, read:
+- Relevant model files in `app/models/`
+- Corresponding spec files in `spec/models/`, `spec/requests/`, or `spec/system/`
+- Factory files in `spec/factories/`
+- Routes in `config/routes.rb` (for request/system specs)
+
+### Step 2: Identify What to Test
+
+**Model specs** — Write when adding/modifying models:
+- Validations (presence, uniqueness, length, format)
+- Associations (belongs_to, has_many, etc.)
+- Scopes
+- Instance methods and class methods
+- Callbacks
+
+**Request specs** — Write when adding controller actions:
+- HTTP status codes (success, redirect, unprocessable)
+- Authentication (authenticated vs. unauthenticated requests)
+- Authorization (own resource vs. others' resource)
+- Response body / redirect target
+- Turbo Stream responses
+
+**System specs** — Write when adding user-facing features:
+- User flow from start to finish
+- Form submissions (success and validation errors)
+- JavaScript interactions (use `:js` metadata)
+- Flash messages and UI feedback
+
+### Step 3: Write the Specs
+
+Follow patterns from existing spec files exactly. Use:
+- `create(:factory_name)` for DB-persisted objects
+- `build(:factory_name)` for in-memory objects
+- `sign_in user` for Devise authentication
+- Descriptive `describe`/`context`/`it` blocks
+
+### Step 4: Output
+
+Provide:
+1. The spec file path(s)
+2. Complete spec content
+3. Which examples should FAIL before implementation (list them)
+4. Brief description of what each group tests
+
+**Do NOT write any implementation code.** Your job ends with the specs.

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Post-edit hook: Auto-run RuboCop autocorrect on edited Ruby files
+# Triggered after Edit/Write tool use via .claude/settings.json
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only process Ruby files when rubocop is available
+if [[ -n "$FILE" && "$FILE" == *.rb && -x ./bin/rubocop ]]; then
+  echo "Running RuboCop autocorrect on $FILE..." >&2
+  ./bin/rubocop --autocorrect-all "$FILE" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/rules/hotwire.md
+++ b/.claude/rules/hotwire.md
@@ -1,0 +1,122 @@
+---
+paths:
+  - "app/javascript/**/*"
+  - "app/views/**/*"
+---
+
+# Hotwire Conventions (Turbo + Stimulus)
+
+## Turbo Frames — Partial Page Updates
+
+Use for scoped page updates (navigation within a section):
+
+```erb
+<%# app/views/spots/_spot.html.erb %>
+<%= turbo_frame_tag dom_id(@spot) do %>
+  <div class="card">
+    <h2><%= @spot.name %></h2>
+    <%= link_to "Edit", edit_spot_path(@spot) %>
+  </div>
+<% end %>
+
+<%# app/views/spots/edit.html.erb %>
+<%= turbo_frame_tag dom_id(@spot) do %>
+  <%= render "form", spot: @spot %>
+<% end %>
+```
+
+Rules:
+- Each frame needs a unique DOM ID (`dom_id(@model)` helper)
+- Clicks inside a frame replace only that frame's content
+- Links outside a frame must use `data-turbo-frame: "_top"` or `data: { turbo_frame: dom_id(@spot) }`
+- Use `<%= turbo_frame_tag "id", src: url %>` for lazy loading
+
+## Turbo Streams — Real-Time Multi-Element Updates
+
+Use for broadcasting changes to multiple parts of the page:
+
+```ruby
+# app/controllers/comments_controller.rb
+def create
+  @comment = @spot.comments.build(comment_params.merge(user: current_user))
+  if @comment.save
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to @spot }
+    end
+  else
+    render :new, status: :unprocessable_entity
+  end
+end
+```
+
+```erb
+<%# app/views/comments/create.turbo_stream.erb %>
+<%= turbo_stream.append "comments" do %>
+  <%= render @comment %>
+<% end %>
+<%= turbo_stream.update "comment-form" do %>
+  <%= render "form", spot: @spot, comment: Comment.new %>
+<% end %>
+```
+
+Available actions: `append`, `prepend`, `replace`, `update`, `remove`, `before`, `after`
+
+Broadcasting (ActionCable):
+```ruby
+# app/models/comment.rb
+after_create_commit -> { broadcast_append_to @spot, target: "comments" }
+after_destroy_commit -> { broadcast_remove_to @spot }
+```
+
+## Stimulus Controllers — JavaScript Behavior
+
+Keep controllers focused on single responsibility:
+
+```javascript
+// app/javascript/controllers/map_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container"]
+  static values = { lat: Number, lng: Number, apiKey: String }
+
+  connect() {
+    this.initMap()
+  }
+
+  disconnect() {
+    // Clean up if needed
+  }
+
+  initMap() {
+    const map = new google.maps.Map(this.containerTarget, {
+      center: { lat: this.latValue, lng: this.lngValue },
+      zoom: 14,
+    })
+    new google.maps.Marker({ position: { lat: this.latValue, lng: this.lngValue }, map })
+  }
+}
+```
+
+Naming conventions:
+- File: `app/javascript/controllers/map_controller.js`
+- HTML: `data-controller="map"`
+- Target: `container` → `data-map-target="container"`
+- Value: `lat` → `data-map-lat-value="35.6762"`
+- Action: `initMap` → `data-action="click->map#initMap"`
+
+Rules:
+- One controller = one responsibility
+- Use `connect()`/`disconnect()` for lifecycle management
+- Use `values` for data from server (not embedded JS variables)
+- Avoid `querySelector` — use Stimulus targets instead
+- Don't use jQuery; use native DOM or Stimulus APIs
+
+## Best Practices
+
+- Prefer Turbo over custom `fetch`/AJAX code
+- Use `turbo_frame_tag` helpers, not raw `<turbo-frame>` HTML
+- Use `data: { turbo_confirm: "確認メッセージ" }` for destructive actions
+- Test Turbo interactions in system specs with Capybara (`:js` metadata)
+- Check existing Stimulus controllers in `app/javascript/controllers/` before creating new ones

--- a/.claude/rules/rails-conventions.md
+++ b/.claude/rules/rails-conventions.md
@@ -1,0 +1,141 @@
+---
+paths:
+  - "app/controllers/**/*"
+  - "app/models/**/*"
+  - "app/helpers/**/*"
+  - "config/routes.rb"
+  - "db/migrate/**/*"
+---
+
+# Rails Conventions
+
+## Controllers — Keep Thin
+
+Controllers handle HTTP, delegate logic to models:
+
+```ruby
+class SpotsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_spot, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_spot!, only: [:edit, :update, :destroy]
+
+  def create
+    @spot = current_user.spots.build(spot_params)
+    if @spot.save
+      redirect_to @spot, notice: "スポットを登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_spot
+    @spot = Spot.find(params[:id])
+  end
+
+  def authorize_spot!
+    redirect_to root_path unless @spot.user == current_user
+  end
+
+  def spot_params
+    params.require(:spot).permit(:name, :address, :description, :prefecture_id)
+  end
+end
+```
+
+Key rules:
+- Use `before_action` for authentication/authorization
+- Use strong parameters (`permit`) always
+- `respond_to` block for Turbo Stream + HTML responses
+- Never put business logic in controllers — use models
+
+## Models — Business Logic Here
+
+```ruby
+class Spot < ApplicationRecord
+  belongs_to :user
+  has_many :comments, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :spot_tags, dependent: :destroy
+  has_many :tags, through: :spot_tags
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :address, presence: true
+  validates :prefecture_id, presence: true
+
+  geocoded_by :address
+  after_validation :geocode, if: :address_changed?
+
+  scope :by_prefecture, ->(id) { where(prefecture_id: id) }
+  scope :recent, -> { order(created_at: :desc) }
+
+  def display_name
+    "#{prefecture.name} / #{name}"
+  end
+end
+```
+
+Key rules:
+- Validations at model level
+- Use `scope` for reusable queries
+- Use `after_validation`/`before_save` callbacks, not controller logic
+- Geocoder handles lat/lng — trigger via `after_validation :geocode`
+
+## Routes — RESTful
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  root "tops#index"
+
+  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+
+  resources :spots do
+    resources :comments, only: [:create, :destroy]
+    resources :bookmarks, only: [:create, :destroy]
+  end
+
+  resources :profiles, only: [:show, :edit, :update]
+end
+```
+
+Key rules:
+- Check existing routes before adding new ones: `bin/rails routes | grep pattern`
+- Use nested resources for clearly owned sub-resources
+- Prefer `only:` to limit to needed actions
+
+## Database Migrations
+
+```bash
+# Generate migration
+bin/rails generate migration AddPrefectureToSpots prefecture:references
+
+# Apply
+bin/rails db:migrate
+
+# Rollback last
+bin/rails db:rollback
+```
+
+Key rules:
+- Never modify existing migrations — create new ones
+- Add indexes for foreign keys and frequently searched columns
+- Use `references` for foreign key columns (creates index automatically)
+
+```ruby
+class AddIndexToSpotsAddress < ActiveRecord::Migration[7.2]
+  def change
+    add_index :spots, :address
+    add_index :spots, [:prefecture_id, :created_at]
+  end
+end
+```
+
+## Security
+
+- Protect actions: `before_action :authenticate_user!`
+- Strong parameters in every controller
+- Use Rails credentials for secrets: `Rails.application.credentials.some_key`
+- Never commit `.env` or secrets — use environment variables
+- Run Brakeman before every PR: `bin/brakeman --no-pager`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,153 @@
+---
+paths:
+  - "spec/**/*"
+  - "app/models/**/*"
+  - "app/controllers/**/*"
+  - "app/views/**/*"
+  - "app/javascript/**/*"
+---
+
+# Testing Conventions (SDD — Spec Driven Development)
+
+## IMPORTANT: Always Write Tests First
+
+The SDD workflow is mandatory:
+1. Write failing RSpec specs BEFORE any implementation code
+2. Run specs to confirm failure: `bundle exec rspec <spec-file>`
+3. Implement minimal code to pass specs
+4. Run full suite: `bundle exec rspec`
+
+Never skip the "write failing tests first" step.
+
+## Spec Organization
+
+### Model Specs (`spec/models/`)
+- Test validations, associations, scopes, and instance methods
+- Test edge cases and error conditions
+- Reference existing files: `spec/models/spot_spec.rb`, `spec/models/user_spec.rb`
+
+### Request Specs (`spec/requests/`)
+- Test HTTP responses, status codes, redirects
+- Test authentication (`authenticate_user!`) and authorization
+- Test Turbo Stream responses for AJAX actions
+- Reference existing: `spec/requests/spots_spec.rb`
+
+### System Specs (`spec/system/`)
+- Test user-facing flows with Capybara
+- Use realistic user interactions (`visit`, `fill_in`, `click_button`)
+- Test with JavaScript (`:js` metadata) only when needed
+- Reference existing system specs for Capybara patterns
+
+## Running Tests
+
+```bash
+bundle exec rspec                              # All tests
+bundle exec rspec spec/models/                 # Models only
+bundle exec rspec spec/requests/               # Requests only
+bundle exec rspec spec/system/                 # System tests only
+bundle exec rspec spec/models/user_spec.rb     # Single file
+bundle exec rspec spec/models/user_spec.rb:42  # Specific line
+```
+
+## FactoryBot Usage
+
+```ruby
+# Persisted object (use for tests requiring DB records)
+user = create(:user)
+spot = create(:spot, user: user)
+
+# In-memory only (faster, use when DB not needed)
+user = build(:user)
+
+# Traits for variations
+admin = create(:user, :admin)
+```
+
+Available factories: `spec/factories/` — check before creating new ones.
+
+## RSpec Patterns
+
+```ruby
+RSpec.describe Spot, type: :model do
+  # Use subject for the object under test
+  subject(:spot) { build(:spot) }
+
+  # Use let for lazy-loaded helpers
+  let(:user) { create(:user) }
+  let!(:spot_with_user) { create(:spot, user: user) }  # let! for eager loading
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:address) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:comments).dependent(:destroy) }
+  end
+
+  describe "#some_method" do
+    context "when condition is true" do
+      it "returns expected result" do
+        expect(spot.some_method).to eq(expected_value)
+      end
+    end
+
+    context "when condition is false" do
+      it "returns nil" do
+        expect(spot.some_method).to be_nil
+      end
+    end
+  end
+end
+```
+
+## Authentication in Specs
+
+```ruby
+# Request specs — use Devise test helpers
+RSpec.describe "Spots", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }  # Devise helper
+
+  describe "GET /spots" do
+    it "returns http success" do
+      get spots_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+end
+
+# System specs
+RSpec.describe "Spots", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    sign_in user  # Devise helper
+  end
+end
+```
+
+## Key Assertions
+
+```ruby
+# HTTP status
+expect(response).to have_http_status(:ok)           # 200
+expect(response).to have_http_status(:created)      # 201
+expect(response).to have_http_status(:redirect)     # 3xx
+expect(response).to redirect_to(spots_path)
+
+# Model state
+expect { action }.to change(Spot, :count).by(1)
+expect { action }.not_to change(Spot, :count)
+
+# Turbo Stream responses
+expect(response.media_type).to eq Mime[:turbo_stream]
+
+# Capybara (system specs)
+expect(page).to have_content("スポット名")
+expect(page).to have_css(".spot-card")
+expect(page).not_to have_selector("form")
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec*)",
+      "Bash(bin/rubocop*)",
+      "Bash(bin/brakeman*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git status)",
+      "Bash(git branch*)",
+      "Bash(git stash*)",
+      "Bash(bin/rails db:migrate)",
+      "Bash(bin/rails db:rollback)",
+      "Bash(bin/rails db:prepare)",
+      "Bash(bin/rails db:seed)",
+      "Bash(bin/rails generate*)",
+      "Bash(bin/rails routes*)",
+      "Bash(bin/rails assets:precompile*)",
+      "Bash(bin/rails runner*)",
+      "Bash(bundle install)",
+      "Bash(yarn install)",
+      "Bash(gh issue*)",
+      "Bash(gh pr*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(bin/rails db:drop*)",
+      "Bash(bin/rails db:reset*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-edit-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: fix-issue
+description: Fix a GitHub issue using SDD workflow. Reads the issue, reproduces the bug with a failing test, then fixes it.
+disable-model-invocation: true
+argument-hint: "[issue-number]"
+---
+
+# Fix GitHub Issue #$ARGUMENTS
+
+Follow the SDD workflow to fix this bug. Write a failing test first, then fix.
+
+---
+
+## Step 1: Understand the Issue
+
+```bash
+gh issue view $ARGUMENTS
+```
+
+Read carefully and identify:
+- What behavior is reported as broken?
+- What is the expected behavior?
+- Are there reproduction steps?
+
+---
+
+## Step 2: Find the Root Cause
+
+Search for relevant code:
+
+1. Find the relevant model/controller/view
+2. Read existing specs for this area
+3. Reproduce the issue mentally — understand WHY it's broken
+
+---
+
+## Step 3: Write a Failing Test
+
+Write a spec that **reproduces the bug**:
+
+```bash
+# Add to existing spec file, or create new one
+bundle exec rspec <spec-file> --format documentation
+```
+
+The spec should FAIL with the current (buggy) code. If it passes, it's not testing the right thing.
+
+For regression tests, add to the appropriate spec file:
+- `spec/models/` — model behavior bugs
+- `spec/requests/` — HTTP/controller bugs
+- `spec/system/` — user-facing UI bugs
+
+---
+
+## Step 4: Fix the Bug
+
+Implement the minimal fix:
+- Fix ONLY what's needed to pass the test
+- Don't refactor unrelated code
+- Don't change behavior beyond what the test covers
+- Follow existing patterns in the codebase
+
+---
+
+## Step 5: Verify
+
+```bash
+# Run the regression test
+bundle exec rspec <spec-file> --format documentation
+
+# Run related specs
+bundle exec rspec spec/models/<model>_spec.rb
+
+# Run full test suite (ensure no regressions)
+bundle exec rspec
+
+# Auto-fix linting
+bin/rubocop -a
+
+# Security scan
+bin/brakeman --no-pager
+```
+
+---
+
+## Step 6: Commit
+
+Create a commit:
+- Message format: `fix: <brief description of what was fixed>`
+- Reference the issue in the PR description
+
+Summarize what was changed and which tests were added.

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: implement-feature
+description: Implement a feature using SDD (Spec Driven Development). Guides you through: explore → write failing specs → implement → verify.
+disable-model-invocation: true
+argument-hint: "[feature description or issue number]"
+---
+
+# Implement Feature with SDD
+
+**Feature**: $ARGUMENTS
+
+Follow the Spec Driven Development workflow strictly. Do NOT skip any step.
+
+---
+
+## Step 1: Explore (Read Before Writing)
+
+Understand the codebase before writing anything:
+
+1. Read the relevant issue if a number was provided: `gh issue view $ARGUMENTS`
+2. Read related models in `app/models/`
+3. Read existing specs for similar features in `spec/`
+4. Check `config/routes.rb` for existing routes
+5. Check `spec/factories/` for available factories
+
+Summarize what you found: what exists, what needs to be added.
+
+---
+
+## Step 2: Write Failing Specs First
+
+**Before writing any implementation code**, write RSpec specs:
+
+### Model specs (if adding model logic)
+- File: `spec/models/<model>_spec.rb`
+- Test validations, associations, scopes, and methods
+
+### Request specs (if adding controller actions)
+- File: `spec/requests/<resource>_spec.rb`
+- Test HTTP status, authentication, authorization
+
+### System specs (if adding user-facing features)
+- File: `spec/system/<feature>_spec.rb`
+- Test user flow with Capybara
+
+Run specs to **confirm they fail**:
+```bash
+bundle exec rspec <spec-file> --format documentation
+```
+
+Show the failing output. If specs pass without implementation, they're testing the wrong thing.
+
+---
+
+## Step 3: Implement
+
+Write minimal code to pass the specs:
+
+1. Generate model/migration if needed: `bin/rails generate model ...`
+2. Run migrations: `bin/rails db:migrate`
+3. Add model logic (validations, associations, methods)
+4. Add controller actions with proper authentication/authorization
+5. Add views using ERB + Turbo Frames/Streams
+6. Add Stimulus controller if JavaScript behavior is needed
+
+Follow existing patterns — read similar code first.
+
+---
+
+## Step 4: Verify
+
+Run specs after implementation:
+
+```bash
+# Run the new specs
+bundle exec rspec <spec-file> --format documentation
+
+# Run full test suite
+bundle exec rspec
+
+# Auto-fix linting
+bin/rubocop -a
+
+# Security scan
+bin/brakeman --no-pager
+```
+
+All steps must pass before creating a PR.
+
+---
+
+## Step 5: Report
+
+Summarize:
+- What specs were written (file paths)
+- What was implemented (files changed)
+- Test results (pass/fail counts)
+- Any rubocop or brakeman findings

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -39,6 +39,19 @@ body:
       required: true
 
   - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: "受け入れ基準（任意）"
+      description: "この機能が完成したとみなせる条件を箇条書きで書いてください。スペック作成に使われます。"
+      placeholder: |
+        例:
+        - スポット詳細ページにLINEシェアボタンが表示される
+        - ボタンをクリックするとLINEシェア画面が開く
+        - スポット名とURLがシェアテキストに含まれる
+    validations:
+      required: false
+
+  - type: textarea
     id: context
     attributes:
       label: "補足（任意）"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,20 @@ Closes #
 
 -
 
+## SDD Confirmation
+
+<!-- Verify that Spec Driven Development was followed -->
+
+- [ ] Specs were written **before** implementation code
+- [ ] Failing specs were confirmed to fail before implementing
+- [ ] All new functionality is covered by specs
+
 ## Test Plan
 
-- [ ] `bundle exec rspec` passes
-- [ ] `bin/rubocop` passes
-- [ ] `bin/brakeman --no-pager` passes
-- [ ] Manual verification (if applicable)
+- [ ] `bundle exec rspec` passes (all tests green)
+- [ ] `bin/rubocop` passes (no linting errors)
+- [ ] `bin/brakeman --no-pager` passes (no security warnings)
+- [ ] Manual verification performed (if applicable)
 
 ## Screenshots (if UI change)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,20 +12,20 @@ NighTrip (https://nightrip.net/) is a night-view spot sharing web application.
 
 ```bash
 # Setup
-bundle install
-yarn install
-bin/rails db:prepare
+bundle install && yarn install && bin/rails db:prepare
 
 # Run locally
 bin/dev
 
-# Tests
+# Tests (SDD — write specs FIRST, then implement)
 bundle exec rspec                    # All tests
-bundle exec rspec spec/models/       # Model tests only
-bundle exec rspec spec/system/       # System tests only
+bundle exec rspec spec/models/       # Model specs only
+bundle exec rspec spec/requests/     # Request specs only
+bundle exec rspec spec/system/       # System specs only
 
-# Linting & Security
-bin/rubocop -f github                # RuboCop
+# Quality checks (run ALL before every PR)
+bin/rubocop -a                       # Auto-fix linting
+bin/rubocop -f github                # CI-style output
 bin/brakeman --no-pager              # Security scan
 
 # Database
@@ -41,33 +41,43 @@ bin/rails assets:precompile RAILS_ENV=test
 
 ```
 app/
-├── controllers/    # Rails controllers (RESTful)
-├── models/         # ActiveRecord models
-├── views/          # ERB templates + Turbo Frames/Streams
+├── controllers/    # Thin RESTful controllers (delegate to models)
+├── models/         # Business logic lives here
+├── views/          # ERB + Turbo Frames/Streams
 ├── javascript/     # Stimulus controllers
 ├── helpers/        # View helpers
 ├── mailers/        # Action Mailer
 └── assets/         # Stylesheets (Tailwind via cssbundling)
 
-config/
-├── routes.rb       # Routing definitions
-├── database.yml    # PostgreSQL config
-└── environments/   # Per-environment settings
-
 spec/
 ├── models/         # Model specs (RSpec)
+├── requests/       # Request/integration specs
 ├── system/         # System specs (Capybara + Selenium)
-├── factories/      # FactoryBot factories
-└── rails_helper.rb # RSpec configuration
+└── factories/      # FactoryBot factories
 ```
 
 ## Key Models
 
 - `User` — Devise authentication + Google OAuth
 - `Spot` — Night-view spots with geolocation (lat/lng via Geocoder)
-- `Comment` — Spot comments (Turbo Streams for real-time)
+- `Comment` — Spot comments (Turbo Streams for real-time updates)
 - `Bookmark` — User bookmarks for spots
 - `Tag` / `SpotTag` — Tagging system
+
+## SDD Workflow — ALWAYS Follow This Order
+
+**IMPORTANT: Spec Driven Development is mandatory for all features.**
+
+1. **Explore** — Read relevant models, controllers, and existing specs before writing anything
+2. **Write failing specs first** — Model specs → Request specs → System specs
+3. **Confirm specs fail** — Run `bundle exec rspec <spec-file>` and verify failure
+4. **Implement** — Write minimal code to make specs pass
+5. **Verify** — Run full suite: `bundle exec rspec`
+6. **Lint** — `bin/rubocop -a`
+7. **Security** — `bin/brakeman --no-pager`
+8. **PR** — Create PR with `needs-review` label
+
+Use the `/implement-feature` skill for guided SDD workflow.
 
 ## Branching & Workflow
 
@@ -75,17 +85,6 @@ spec/
 - Feature: `feature/issue-{number}-{slug}`
 - Bug fix: `fix/issue-{number}-{slug}`
 - Maintenance: `chore/issue-{number}-{slug}`
-
-### Development Workflow (SDD - Spec Driven Development)
-1. Check for Issues with `approved` label
-2. Create feature branch from `main`
-3. Write/update specs first, then implement
-4. Run full test suite: `bundle exec rspec`
-5. Run linter: `bin/rubocop -a` (auto-correct safe violations)
-6. Run security scan: `bin/brakeman --no-pager`
-7. Create PR with structured description
-8. Add `needs-review` label to PR
-9. After merge to `main`, Render auto-deploys
 
 ### Label System
 | Label | Meaning |
@@ -114,9 +113,13 @@ Required in production (Render):
 
 ## Coding Conventions
 
-- Follow existing Rails conventions and Rubocop rules (`.rubocop.yml`)
-- Use Hotwire (Turbo Frames/Streams + Stimulus) for interactivity — no heavy JS frameworks
-- Use daisyUI component classes for UI elements
 - Japanese UI text, English code/comments
-- Always write RSpec tests for new features
-- Keep controllers thin, models contain business logic
+- Controllers thin — business logic belongs in models
+- Hotwire (Turbo Frames/Streams + Stimulus) for all interactivity — no heavy JS frameworks
+- daisyUI component classes for UI elements
+- Follow `.rubocop.yml` (rubocop-rails-omakase)
+
+### Detailed Rules (auto-loaded by Claude Code)
+- Testing/SDD: @.claude/rules/testing.md
+- Rails conventions: @.claude/rules/rails-conventions.md
+- Hotwire conventions: @.claude/rules/hotwire.md


### PR DESCRIPTION
Closes #393

Claude Code公式ドキュメントを調査し、高度なSDD体制を構築しました。

## 主な変更
- `.claude/settings.json`: パーミッション制御 + PostToolUseフック
- `.claude/rules/`: モジュール型ルール（testing, rails-conventions, hotwire）
- `.claude/agents/`: spec-writer・SDD専門エージェント
- `.claude/skills/`: implement-feature, fix-issueスキル
- CLAUDE.md, PRテンプレートのSDD強化

## Test plan
- [ ] `bundle exec rspec` passes
- [ ] `bin/rubocop` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)