### PR TITLE
feat: GitHub Mobileワークフローの強化とClaude Code開発体制の整備

### DIFF
--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: help
+description: Show available Claude Code commands, skills, and the GitHub Mobile workflow for NighTrip development.
+disable-model-invocation: true
+argument-hint: ""
+---
+
+# Claude Code — NighTrip Quick Reference
+
+Provide a clear, formatted summary of all available commands and workflows.
+
+---
+
+## Available Slash Commands (Skills)
+
+| Command | What It Does |
+|---------|-------------|
+| `/implement-feature [description or issue#]` | Full SDD workflow: explore → write failing specs → implement → verify |
+| `/fix-issue [issue-number]` | Reproduce bug with failing test → fix → verify |
+| `/review-pr [pr-number]` | Thorough code review: Rails conventions, security, test coverage |
+| `/help` | Show this reference |
+
+---
+
+## GitHub Mobile Workflow
+
+### Starting a Task from Mobile
+
+**Option A — Label Trigger (for new features/bugs):**
+1. Create an Issue using the template (Feature Request, Bug Report, etc.)
+2. Describe what you want clearly
+3. Add the `approved` label → Claude starts working automatically
+
+**Option B — Comment Trigger (for quick instructions):**
+1. Open any Issue or PR
+2. Write a comment with `@claude [your instruction]`
+3. Claude responds and implements
+
+### Common Mobile Patterns
+
+```
+# On an issue — ask Claude to implement it
+@claude implement this feature
+
+# On a PR — ask Claude to fix a review comment
+@claude fix the RuboCop offense in spots_controller.rb
+
+# On a PR — get a full code review
+/review-pr
+
+# On an issue — ask Claude to write specs first
+@claude write the failing specs for this feature
+
+# Ask Claude anything about the codebase
+@claude explain how Turbo Streams are used in the comments feature
+```
+
+---
+
+## Label Reference
+
+| Label | Meaning | Who Sets It |
+|-------|---------|-------------|
+| `proposal` | Claude proposed an approach | Auto (Issue template) |
+| `approved` | Approved — Claude starts work | **You** |
+| `in-progress` | Claude is implementing | Auto (workflow) |
+| `needs-review` | PR ready for your review | Claude |
+| `auto-merge` | Merge automatically after CI | You (optional) |
+| `bug` | Bug report | Auto (Issue template) |
+| `maintenance` | Maintenance task | Auto (Issue template) |
+
+---
+
+## SDD Quick Summary
+
+Always: **Specs first → Fail → Implement → Pass → Lint → Security → PR**
+
+1. Write failing RSpec specs
+2. Run `bundle exec rspec <spec-file>` → must fail
+3. Implement minimal code
+4. Run `bundle exec rspec` → all green
+5. Run `bin/rubocop -a` → no offenses
+6. Run `bin/brakeman --no-pager` → no warnings
+7. Create PR with `needs-review` label
+
+---
+
+## Useful `@claude` Prompts from Mobile
+
+- `@claude what does [file/feature] do?` — Get explanations
+- `@claude add a spec for [scenario]` — Add missing test coverage
+- `@claude refactor [specific code]` — Targeted refactoring
+- `@claude is this PR safe to merge?` — Quick security/quality check
+- `@claude create a PR for this issue` — Generate PR from issue branch

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: review-pr
+description: Review the current PR's changes for code quality, security, and Rails best practices. Ideal for triggering a thorough review from GitHub Mobile.
+disable-model-invocation: true
+argument-hint: "[pr-number or leave empty for current branch]"
+---
+
+# PR Code Review
+
+**Target:** $ARGUMENTS
+
+Perform a thorough code review of the PR changes. Follow each step below.
+
+---
+
+## Step 1: Identify the PR
+
+If a PR number was provided, fetch its details:
+```bash
+gh pr view $ARGUMENTS
+gh pr diff $ARGUMENTS
+```
+
+If no argument given, review the current branch's uncommitted or recently committed changes:
+```bash
+git log main..HEAD --oneline
+git diff main..HEAD
+```
+
+List files changed:
+```bash
+gh pr view $ARGUMENTS --json files --jq '.files[].path' 2>/dev/null || git diff main..HEAD --name-only
+```
+
+---
+
+## Step 2: Read the Changed Files
+
+For each changed file, read the full file (not just the diff) to understand context:
+- Models → check validations, associations, business logic
+- Controllers → check authentication, authorization, strong params
+- Views → check for XSS, user data rendering, Turbo integration
+- Migrations → check data integrity, indexes, reversibility
+- Specs → check coverage, edge cases, factory usage
+
+---
+
+## Step 3: Review Against Checklist
+
+### Rails Best Practices
+- [ ] Controllers are thin (business logic in models)
+- [ ] `before_action :authenticate_user!` on all sensitive actions
+- [ ] Strong parameters used (`permit` with explicit fields)
+- [ ] Scopes and class methods used instead of complex queries in controllers
+- [ ] Geocoder triggered via `after_validation :geocode` (not in controllers)
+- [ ] Turbo Streams used for real-time updates (not custom AJAX)
+
+### Code Quality
+- [ ] Methods are short and focused (single responsibility)
+- [ ] No duplication — DRY where it makes sense
+- [ ] Variable/method names are clear and descriptive
+- [ ] No dead code or unused variables
+
+### Testing (SDD)
+- [ ] New features have corresponding specs in `spec/`
+- [ ] Specs cover happy path AND error cases
+- [ ] Factories used (not fixtures), from `spec/factories/`
+- [ ] System specs cover user-facing flows
+
+### Security
+- [ ] No secrets hardcoded in source code
+- [ ] No `html_safe` or `raw` on user input without sanitization
+- [ ] No SQL string interpolation (use placeholders)
+- [ ] Authorization: users can only access their own resources
+
+---
+
+## Step 4: Run Automated Checks
+
+```bash
+# Security scan (if code was checked out)
+bin/brakeman --no-pager 2>/dev/null || echo "Brakeman not available in this context"
+```
+
+---
+
+## Step 5: Write Review Summary
+
+Structure the feedback as:
+
+**Summary**
+One paragraph describing what the PR does and overall assessment.
+
+**Issues Found** (if any)
+- 🔴 **MUST FIX** — Critical bugs or security issues
+- 🟡 **SHOULD FIX** — Code quality or convention issues
+- 🟢 **CONSIDER** — Minor improvements or suggestions
+
+**Looks Good**
+Highlight what's done well.
+
+**Verdict**
+- ✅ Approved — ready to merge
+- ⚠️ Needs changes — address issues above before merging

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -50,3 +50,11 @@ body:
       description: "画像をドラッグ＆ドロップで添付"
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Claude Code を使って修正するには:**
+        このIssueを作成したら `approved` ラベルを付けるとClaudeが自動でバグ修正を開始します。
+        または、コメントで `@claude fix this bug` と書いてもOKです。

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -59,3 +59,11 @@ body:
       placeholder: "任意: 追加情報があれば"
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Claude Code を使って実装するには:**
+        このIssueを作成したら `approved` ラベルを付けるとClaudeが自動で実装を開始します。
+        または、コメントで `@claude implement this` と書いてもOKです。

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -33,3 +33,11 @@ body:
       label: "補足（任意）"
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Claude Code を使ってタスクを実行するには:**
+        このIssueを作成したら `approved` ラベルを付けるとClaudeが自動で作業を開始します。
+        または、コメントで `@claude [指示内容]` と書いてもOKです。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,59 @@ spec/
 - `Bookmark` — User bookmarks for spots
 - `Tag` / `SpotTag` — Tagging system
 
+## GitHub Mobile Workflow
+
+Claude Code can be triggered directly from GitHub Mobile — no local setup needed.
+
+### Two Ways to Trigger Claude
+
+**1. Label trigger** — for new issues (feature requests, bug reports):
+1. Create issue via mobile using the template
+2. Add the `approved` label → Claude starts implementing automatically
+
+**2. Comment trigger** — for quick instructions on any issue or PR:
+- Type `@claude [instruction]` in any comment → Claude responds and acts
+
+### Available Slash Commands (type in any issue/PR comment)
+
+| Command | What It Does |
+|---------|-------------|
+| `/implement-feature [#issue or description]` | SDD workflow: explore → specs → implement → verify |
+| `/fix-issue [issue-number]` | Reproduce bug with failing test, then fix |
+| `/review-pr [pr-number]` | Full code review: Rails conventions, security, test coverage |
+| `/help` | Show all available commands |
+
+### Common Mobile Usage Examples
+
+```
+# Ask Claude to implement an approved issue
+@claude implement this feature
+
+# Ask Claude to fix a specific problem in a PR
+@claude fix the RuboCop offenses in app/controllers/spots_controller.rb
+
+# Get a full PR review before merging
+/review-pr
+
+# Ask Claude to explain code
+@claude how does the bookmark feature work?
+
+# Ask Claude to add missing specs
+@claude write system specs for the spot search flow
+```
+
+### Label Flow
+
+```
+[You] Create issue → proposal
+[You] Add label → approved
+[Claude] Starts work → in-progress
+[Claude] Opens PR → needs-review
+[You] Review & approve → auto-merge (optional)
+```
+
+---
+
 ## SDD Workflow — ALWAYS Follow This Order
 
 **IMPORTANT: Spec Driven Development is mandatory for all features.**


### PR DESCRIPTION
Closes #397

## 変更内容

- CLAUDE.mdにGitHub Mobileワークフローセクションを追加
- `/review-pr` スキル追加（PRレビューをモバイルから1コマンドで起動）
- `/help` スキル追加（利用可能なコマンドのクイックリファレンス）
- IssueテンプレートにClaudeトリガーのヒントを追加

Generated with [Claude Code](https://claude.ai/code)